### PR TITLE
update guards on deleteSubname

### DIFF
--- a/packages/ensjs/src/functions/deleteSubname.test.ts
+++ b/packages/ensjs/src/functions/deleteSubname.test.ts
@@ -29,7 +29,10 @@ describe('deleteSubname', () => {
     const result = await registry.owner(namehash('test.with-subnames.eth'))
     expect(result).toBe('0x0000000000000000000000000000000000000000')
   })
+
   it('should allow deleting a subname on the nameWrapper', async () => {
+    const nameWrapper = await ensInstance.contracts!.getNameWrapper()!
+
     const tx = await ensInstance.deleteSubname(
       'test.wrapped-with-subnames.eth',
       {
@@ -40,10 +43,27 @@ describe('deleteSubname', () => {
     expect(tx).toBeTruthy()
     await tx.wait()
 
-    const nameWrapper = await ensInstance.contracts!.getNameWrapper()!
     const result = await nameWrapper.ownerOf(
       namehash('test.wrapped-with-subnames.eth'),
     )
     expect(result).toBe('0x0000000000000000000000000000000000000000')
+  })
+
+  it('should not allow deleting 1LD', async () => {
+    await expect(
+      ensInstance.deleteSubname('eth', {
+        contract: 'nameWrapper',
+        addressOrIndex: 1,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it('should not allow deleting 2LD', async () => {
+    await expect(
+      ensInstance.deleteSubname('test123.eth', {
+        contract: 'registry',
+        addressOrIndex: 1,
+      }),
+    ).rejects.toThrow()
   })
 })

--- a/packages/ensjs/src/functions/deleteSubname.ts
+++ b/packages/ensjs/src/functions/deleteSubname.ts
@@ -13,18 +13,14 @@ export default async function (
 ) {
   const labels = name.split('.')
 
-  if (labels.length !== 3) {
-    throw new Error('ENS.js currently only supports deleting 2LDs, not TLDs')
-  }
-
-  if (labels[2] !== 'eth') {
-    throw new Error('ENS.js currently only supports deleting .eth 2LDs')
+  if (labels.length < 3) {
+    throw new Error(`${name} is not a valid subname`)
   }
 
   const label = labels.shift() as string
   const labelhash = ethers.utils.solidityKeccak256(['string'], [label])
   const parentNodehash = namehash(labels.join('.'))
-
+ 
   switch (contract) {
     case 'registry': {
       const registry = (await contracts!.getRegistry()!).connect(signer)

--- a/packages/ensjs/src/functions/deleteSubname.ts
+++ b/packages/ensjs/src/functions/deleteSubname.ts
@@ -20,7 +20,7 @@ export default async function (
   const label = labels.shift() as string
   const labelhash = ethers.utils.solidityKeccak256(['string'], [label])
   const parentNodehash = namehash(labels.join('.'))
- 
+
   switch (contract) {
     case 'registry': {
       const registry = (await contracts!.getRegistry()!).connect(signer)


### PR DESCRIPTION
Remove guards that accepted only 3LD and .eth TLDs.

New guard that only checks that name is at least a 3LD