### PR TITLE
fix: getHistory for subnames

### DIFF
--- a/packages/ensjs/src/functions/getExpiry.ts
+++ b/packages/ensjs/src/functions/getExpiry.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { keccak256 as solidityKeccak256 } from '@ethersproject/solidity'
 import { ENSArgs } from '..'
 import { namehash } from '../utils/normalise'
+import { checkIsDotEth } from '../utils/validation'
 
 type ContractOption = 'registrar' | 'nameWrapper'
 
@@ -56,7 +57,7 @@ const getContractToUse = (
   labels: string[],
 ) => {
   if (contract) return contract
-  if (labels.length === 2 && labels[1] === 'eth') {
+  if (checkIsDotEth(labels)) {
     return 'registrar'
   }
   return 'nameWrapper'

--- a/packages/ensjs/src/functions/getHistory.test.ts
+++ b/packages/ensjs/src/functions/getHistory.test.ts
@@ -35,4 +35,15 @@ describe('getHistory', () => {
       expect(result).toHaveProperty('registration')
     }
   })
+  it('should return the history of a subname', async () => {
+    const result = await ensInstance.getHistory(
+      'test.wrapped-with-subnames.eth',
+    )
+    expect(result).toBeTruthy()
+    if (result) {
+      expect(result).toHaveProperty('domain')
+      expect(result).toHaveProperty('resolver')
+      expect(result).not.toHaveProperty('registration')
+    }
+  })
 })

--- a/packages/ensjs/src/functions/getHistory.ts
+++ b/packages/ensjs/src/functions/getHistory.ts
@@ -27,6 +27,7 @@ import {
   VersionChanged,
   WrappedTransfer,
 } from '../utils/subgraph-types'
+import { checkIsDotEth } from '../utils/validation'
 
 type DomainEvent =
   | 'NewOwner'
@@ -276,7 +277,7 @@ export async function getHistory(
 
   const nameHash = namehash(name)
   const labels = name.split('.')
-  const is2ldEth = labels.length === 2 && labels[1] === 'eth'
+  const is2ldEth = checkIsDotEth(labels)
 
   const response = await client.request(query, {
     namehash: nameHash,

--- a/packages/ensjs/src/functions/getOwner.ts
+++ b/packages/ensjs/src/functions/getOwner.ts
@@ -4,6 +4,7 @@ import { hexStripZeros } from '@ethersproject/bytes'
 import { ENSArgs } from '..'
 import { labelhash } from '../utils/labels'
 import { namehash as makeNamehash } from '../utils/normalise'
+import { checkIsDotEth } from '../utils/validation'
 
 type Owner = {
   registrant?: string
@@ -87,7 +88,7 @@ const raw = async (
 
   const data: { to: string; data: string }[] = [registryData, nameWrapperData]
 
-  if (labels.length === 2 && labels[1] === 'eth') {
+  if (checkIsDotEth(labels)) {
     data.push(registrarData)
   }
 

--- a/packages/ensjs/src/functions/unwrapName.ts
+++ b/packages/ensjs/src/functions/unwrapName.ts
@@ -2,6 +2,7 @@ import { keccak256 as solidityKeccak256 } from '@ethersproject/solidity'
 
 import { ENSArgs } from '..'
 import { namehash } from '../utils/normalise'
+import { checkIsDotEth } from '../utils/validation'
 
 export default async function (
   { contracts, signer }: ENSArgs<'contracts' | 'signer'>,
@@ -20,7 +21,7 @@ export default async function (
 
   const nameWrapper = (await contracts!.getNameWrapper()!).connect(signer)
 
-  if (labels.length === 2 && labels[1] === 'eth') {
+  if (checkIsDotEth(labels)) {
     if (!newRegistrant) {
       throw new Error('newRegistrant must be specified for .eth names')
     }

--- a/packages/ensjs/src/functions/wrapName.ts
+++ b/packages/ensjs/src/functions/wrapName.ts
@@ -4,6 +4,7 @@ import { keccak256 as solidityKeccak256 } from '@ethersproject/solidity'
 import { ENSArgs } from '..'
 import { CombinedFuseInput, encodeFuses } from '../utils/fuses'
 import { hexEncodeName } from '../utils/hexEncodedName'
+import { checkIsDotEth } from '../utils/validation'
 import { Expiry, wrappedLabelLengthCheck } from '../utils/wrapper'
 
 async function wrapETH(
@@ -84,7 +85,7 @@ export default async function (
   const labels = name.split('.')
   wrappedLabelLengthCheck(labels[0])
 
-  if (labels.length === 2 && labels[1] === 'eth') {
+  if (checkIsDotEth(labels)) {
     switch (typeof fuseOptions) {
       case 'object': {
         decodedFuses = encodeFuses(fuseOptions)

--- a/packages/ensjs/src/utils/validation.ts
+++ b/packages/ensjs/src/utils/validation.ts
@@ -70,3 +70,6 @@ export const parseInputType = (input: string): InputType => {
     type: 'label',
   }
 }
+
+export const checkIsDotEth = (labels: string[]) =>
+  labels.length === 2 && labels[1] === 'eth'


### PR DESCRIPTION
previously subnames would error with getHistory

result now only returns `regsistration` property if name is a 2ld .eth, fixes error