### PR TITLE
fix: ensure createdAt is always requested in getNames

### DIFF
--- a/packages/ensjs/src/functions/getNames.ts
+++ b/packages/ensjs/src/functions/getNames.ts
@@ -144,6 +144,7 @@ const getNames = async (
     parent {
         name
     }
+    createdAt
   `
 
   let queryVars: object = {}
@@ -168,7 +169,6 @@ const getNames = async (
           }
           domains(first: 1000) {
             ${domainQueryData}
-            createdAt
             registration {
               registrationDate
               expiryDate
@@ -203,7 +203,6 @@ const getNames = async (
           account(id: $id) {
             domains(orderBy: $orderBy, orderDirection: $orderDirection) {
               ${domainQueryData}
-              createdAt
               registration {
                 registrationDate
                 expiryDate
@@ -234,7 +233,6 @@ const getNames = async (
               orderDirection: $orderDirection
             ) {
               ${domainQueryData}
-              createdAt
             }
           }
         }
@@ -267,7 +265,6 @@ const getNames = async (
             fuses
             domain {
               ${domainQueryData}
-              createdAt
             }
           }
         }
@@ -298,7 +295,6 @@ const getNames = async (
             fuses
             domain {
               ${domainQueryData}
-              createdAt
             }
           }
         }


### PR DESCRIPTION
previously `createdAt` in `getNames()` for some queries was not requested, which led to invalid dates being returned, now `createdAt` is fetched for every domain query.