### PR TITLE
fix: allow empty address to be set as a record

### DIFF
--- a/packages/ensjs/src/utils/recordHelpers.test.ts
+++ b/packages/ensjs/src/utils/recordHelpers.test.ts
@@ -1,0 +1,19 @@
+import { PublicResolver__factory } from '../generated'
+import { namehash } from './normalise'
+import { generateSetAddr } from './recordHelpers'
+
+describe('generateSetAddr()', () => {
+  it('should allow empty string as address', () => {
+    expect(() =>
+      generateSetAddr(
+        namehash('test'),
+        'BNB',
+        '',
+        PublicResolver__factory.connect(
+          '0x0000000000000000000000000000000000000000',
+          undefined as any,
+        ),
+      ),
+    ).not.toThrowError()
+  })
+})

--- a/packages/ensjs/src/utils/recordHelpers.ts
+++ b/packages/ensjs/src/utils/recordHelpers.ts
@@ -38,7 +38,8 @@ export const generateSetAddr = (
     coinTypeInstance = formatsByName[coinType.toUpperCase()]
   }
   const inputCoinType = coinTypeInstance.coinType
-  const encodedAddress = coinTypeInstance.decoder(address)
+  const encodedAddress =
+    address !== '' ? coinTypeInstance.decoder(address) : '0x'
   return resolver?.interface.encodeFunctionData(
     'setAddr(bytes32,uint256,bytes)',
     [namehash, inputCoinType, encodedAddress],


### PR DESCRIPTION
previously you couldn't set any address record to be blank, you needed to provide the equivalent empty bytes address value for the address format (e.g. `0x0000000000000000000000000000000000000000` for ETH).

now instead of needing to provide the empty address itself, you can just provide a blank string and it will set the record to null