### PR TITLE
fix: allow setting empty contenthash

### DIFF
--- a/packages/ensjs/src/utils/recordHelpers.test.ts
+++ b/packages/ensjs/src/utils/recordHelpers.test.ts
@@ -1,6 +1,6 @@
 import { PublicResolver__factory } from '../generated'
 import { namehash } from './normalise'
-import { generateSetAddr } from './recordHelpers'
+import { generateRecordCallArray, generateSetAddr } from './recordHelpers'
 
 describe('generateSetAddr()', () => {
   it('should allow empty string as address', () => {
@@ -15,5 +15,22 @@ describe('generateSetAddr()', () => {
         ),
       ),
     ).not.toThrowError()
+  })
+})
+
+describe('generateRecordCallArray()', () => {
+  it('should allow empty string as contenthash', () => {
+    expect(
+      generateRecordCallArray(
+        namehash('test'),
+        { contentHash: '' },
+        PublicResolver__factory.connect(
+          '0x0000000000000000000000000000000000000000',
+          undefined as any,
+        ),
+      ),
+    ).toEqual([
+      '0x304e6ade04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd600000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000',
+    ])
   })
 })

--- a/packages/ensjs/src/utils/recordHelpers.ts
+++ b/packages/ensjs/src/utils/recordHelpers.ts
@@ -99,6 +99,8 @@ export function generateSingleRecordCall<T extends RecordTypes>(
         const encoded = encodeContenthash(record)
         if (encoded.error) throw new Error(encoded.error)
         _contentHash = encoded.encoded as string
+      } else {
+        _contentHash = '0x'
       }
       return resolver.interface.encodeFunctionData('setContenthash', [
         namehash,
@@ -150,7 +152,7 @@ export const generateRecordCallArray = (
     )
   }
 
-  if (records.contentHash) {
+  if (typeof records.contentHash === 'string') {
     const data = generateSingleRecordCall(
       namehash,
       resolver,


### PR DESCRIPTION
previously empty content hash values couldn't be set when using a multicall because `generateRecordCallArray()` did a boolean check for the contentHash property existence, which excludes empty strings. changed check to be for typeof string, and added a default value of `0x` in `generateSingleRecordCall()`