### PR TITLE
Fix: Empty address for ETH fails 

### DIFF
--- a/packages/ensjs/src/functions/setRecord.test.ts
+++ b/packages/ensjs/src/functions/setRecord.test.ts
@@ -1,3 +1,4 @@
+import { formatsByName } from '@ensdomains/address-encoder'
 import { decodeFirst } from 'cbor'
 import { BigNumber } from 'ethers'
 import { arrayify, toUtf8String } from 'ethers/lib/utils'
@@ -145,6 +146,22 @@ describe('setRecord', () => {
     // record as hex
     expect(resultEmptyAddr).toBe('0x')
   })
+
+  Object.keys(formatsByName).forEach((coinName) => {
+    it(`should allow an empty address record for ${coinName}`, async () => {
+      const tx = await ensInstance.setRecord('test123.eth', {
+        type: 'addr',
+        record: {
+          key: coinName,
+          value: '',
+        },
+        addressOrIndex: 1,
+      })
+      expect(tx).toBeTruthy()
+      await tx.wait()
+    })
+  })
+
   it('should allow a contenthash record set', async () => {
     const tx = await ensInstance.setRecord('test123.eth', {
       type: 'contentHash',

--- a/packages/ensjs/src/utils/recordHelpers.ts
+++ b/packages/ensjs/src/utils/recordHelpers.ts
@@ -38,8 +38,12 @@ export const generateSetAddr = (
     coinTypeInstance = formatsByName[coinType.toUpperCase()]
   }
   const inputCoinType = coinTypeInstance.coinType
-  const encodedAddress =
-    address !== '' ? coinTypeInstance.decoder(address) : '0x'
+  let encodedAddress = address !== '' ? coinTypeInstance.decoder(address) : '0x'
+  if (inputCoinType === 60 && encodedAddress === '0x')
+    encodedAddress = coinTypeInstance.decoder(
+      '0x0000000000000000000000000000000000000000',
+    )
+
   return resolver?.interface.encodeFunctionData(
     'setAddr(bytes32,uint256,bytes)',
     [namehash, inputCoinType, encodedAddress],


### PR DESCRIPTION
* Added tests for every coin type to see if the transaction will be successful with '0x'. Only eth doesn't not work. requires a 0x0000000000 address.
