### PR TITLE
gracefully fail getSubnames

### DIFF
--- a/packages/ensjs/src/functions/getSubnames.ts
+++ b/packages/ensjs/src/functions/getSubnames.ts
@@ -150,7 +150,7 @@ const largeQuery = async (
     })
     .finally(debugSubgraphLatency)
 
-  const domain = response?.domain
+  const domain = response?.domain || { subdomains: [], subdomainCount: 0 }
   const subdomains = domain.subdomains.map(
     ({ wrappedDomain, ...subname }: Domain) => {
       const decrypted = decryptName(subname.name!)


### PR DESCRIPTION
CCIP names don't have subnames, so need to make function gracefully fail to default results.