### PR TITLE
chore: add holesky support

### DIFF
--- a/packages/ensjs/src/contracts/consts.ts
+++ b/packages/ensjs/src/contracts/consts.ts
@@ -13,7 +13,12 @@ type ChainContract = {
   blockCreated?: number
 }
 
-export const supportedChains = ['homestead', 'goerli', 'sepolia'] as const
+export const supportedChains = [
+  'homestead',
+  'goerli',
+  'sepolia',
+  'holesky',
+] as const
 export const supportedContracts = [
   'ensBaseRegistrarImplementation',
   'ensBulkRenewal',
@@ -127,6 +132,38 @@ export const addresses = {
       address: '0xBaBC7678D7A63104f1658c11D6AE9A21cdA09725',
     },
   },
+  holesky: {
+    ensBaseRegistrarImplementation: {
+      address: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
+    },
+    ensBulkRenewal: {
+      address: '0xbc4cfB363F948E64Cd73Da6438F64CB37E2e33d1',
+    },
+    ensDnsRegistrar: {
+      address: '0x458d278AEd4cE82BAeC384170f39198b01B8351c',
+    },
+    ensDnssecImpl: {
+      address: '0x283af0b28c62c092c9727f1ee09c02ca627eb7f5',
+    },
+    ensEthRegistrarController: {
+      address: '0x179Be112b24Ad4cFC392eF8924DfA08C20Ad8583',
+    },
+    ensNameWrapper: {
+      address: '0xab50971078225D365994dc1Edcb9b7FD72Bb4862',
+    },
+    ensPublicResolver: {
+      address: '0x9010A27463717360cAD99CEA8bD39b8705CCA238',
+    },
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    },
+    ensReverseRegistrar: {
+      address: '0x132AC0B116a73add4225029D1951A9A707Ef673f',
+    },
+    ensUniversalResolver: {
+      address: '0x2548a7E09deE955c4d97688dcB6C5b24085725f5',
+    },
+  },
 } as const satisfies Record<
   SupportedChain,
   Record<SupportedContract, { address: Address }>
@@ -152,6 +189,11 @@ export const subgraphs = {
   sepolia: {
     ens: {
       url: 'https://api.studio.thegraph.com/query/49574/enssepolia/version/latest',
+    },
+  },
+  holesky: {
+    ens: {
+      url: 'https://api.studio.thegraph.com/query/49574/ensholesky/version/latest',
     },
   },
 } as const satisfies Record<SupportedChain, Subgraphs>

--- a/packages/ensjs/src/contracts/consts.ts
+++ b/packages/ensjs/src/contracts/consts.ts
@@ -16,15 +16,15 @@ type ChainContract = {
 export const supportedChains = ['homestead', 'goerli', 'sepolia'] as const
 export const supportedContracts = [
   'ensBaseRegistrarImplementation',
+  'ensBulkRenewal',
   'ensDnsRegistrar',
+  'ensDnssecImpl',
   'ensEthRegistrarController',
   'ensNameWrapper',
   'ensPublicResolver',
-  'ensReverseRegistrar',
-  'ensBulkRenewal',
-  'ensDnssecImpl',
-  'ensUniversalResolver',
   'ensRegistry',
+  'ensReverseRegistrar',
+  'ensUniversalResolver',
 ] as const
 
 export type SupportedChain = (typeof supportedChains)[number]
@@ -32,14 +32,17 @@ export type SupportedContract = (typeof supportedContracts)[number]
 
 export const addresses = {
   homestead: {
-    ensRegistry: {
-      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    },
     ensBaseRegistrarImplementation: {
-      address: '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
+      address: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
+    },
+    ensBulkRenewal: {
+      address: '0xa12159e5131b1eEf6B4857EEE3e1954744b5033A',
     },
     ensDnsRegistrar: {
       address: '0x58774Bb8acD458A640aF0B88238369A167546ef2',
+    },
+    ensDnssecImpl: {
+      address: '0x0fc3152971714E5ed7723FAFa650F86A4BaF30C5',
     },
     ensEthRegistrarController: {
       address: '0x253553366Da8546fC250F225fe3d25d0C782303b',
@@ -50,28 +53,28 @@ export const addresses = {
     ensPublicResolver: {
       address: '0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63',
     },
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    },
     ensReverseRegistrar: {
       address: '0xa58E81fe9b61B5c3fE2AFD33CF304c454AbFc7Cb',
-    },
-    ensBulkRenewal: {
-      address: '0xa12159e5131b1eEf6B4857EEE3e1954744b5033A',
-    },
-    ensDnssecImpl: {
-      address: '0x0fc3152971714E5ed7723FAFa650F86A4BaF30C5',
     },
     ensUniversalResolver: {
       address: '0x8cab227b1162f03b8338331adaad7aadc83b895e',
     },
   },
   goerli: {
-    ensRegistry: {
-      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    },
     ensBaseRegistrarImplementation: {
-      address: '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
+      address: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
+    },
+    ensBulkRenewal: {
+      address: '0x6d9F26FfBcF1c6f0bAe9F2C1f7fBe8eE6B1d8d4d',
     },
     ensDnsRegistrar: {
       address: '0x8edc487D26F6c8Fa76e032066A3D4F87E273515d',
+    },
+    ensDnssecImpl: {
+      address: '0xF427c4AdED8B6dfde604865c1a7E953B160C26f0',
     },
     ensEthRegistrarController: {
       address: '0xCc5e7dB10E65EED1BBD105359e7268aa660f6734',
@@ -82,28 +85,28 @@ export const addresses = {
     ensPublicResolver: {
       address: '0xd7a4F6473f32aC2Af804B3686AE8F1932bC35750',
     },
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    },
     ensReverseRegistrar: {
       address: '0x6d9F26FfBcF1c6f0bAe9F2C1f7fBe8eE6B1d8d4d',
-    },
-    ensBulkRenewal: {
-      address: '0x6d9F26FfBcF1c6f0bAe9F2C1f7fBe8eE6B1d8d4d',
-    },
-    ensDnssecImpl: {
-      address: '0xF427c4AdED8B6dfde604865c1a7E953B160C26f0',
     },
     ensUniversalResolver: {
       address: '0xfc4AC75C46C914aF5892d6d3eFFcebD7917293F1',
     },
   },
   sepolia: {
-    ensRegistry: {
-      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    },
     ensBaseRegistrarImplementation: {
-      address: '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
+      address: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
+    },
+    ensBulkRenewal: {
+      address: '0x4EF77b90762Eddb33C8Eba5B5a19558DaE53D7a1',
     },
     ensDnsRegistrar: {
       address: '0x5a07C75Ae469Bf3ee2657B588e8E6ABAC6741b4f',
+    },
+    ensDnssecImpl: {
+      address: '0xe62E4b6cE018Ad6e916fcC24545e20a33b9d8653',
     },
     ensEthRegistrarController: {
       address: '0xFED6a969AaA60E4961FCD3EBF1A2e8913ac65B72',
@@ -114,14 +117,11 @@ export const addresses = {
     ensPublicResolver: {
       address: '0x8FADE66B79cC9f707aB26799354482EB93a5B7dD',
     },
+    ensRegistry: {
+      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+    },
     ensReverseRegistrar: {
       address: '0xA0a1AbcDAe1a2a4A2EF8e9113Ff0e02DD81DC0C6',
-    },
-    ensBulkRenewal: {
-      address: '0x4EF77b90762Eddb33C8Eba5B5a19558DaE53D7a1',
-    },
-    ensDnssecImpl: {
-      address: '0xe62E4b6cE018Ad6e916fcC24545e20a33b9d8653',
     },
     ensUniversalResolver: {
       address: '0xBaBC7678D7A63104f1658c11D6AE9A21cdA09725',


### PR DESCRIPTION
base is new dnssec oracle branch because holesky only has new dnsregistrar

changes:
- contract names now in alphabetical order in `addresses`
- added `holesky` to `supportedChains`
- added all holesky contracts to `addresses`
- added holesky subgraph