### PR TITLE
feat: local ur unwrap

### DIFF
--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -139,11 +139,11 @@
     "typedoc": "^0.24.8",
     "typedoc-plugin-markdown": "^4.0.0-next.16",
     "typescript": "5.3.2",
-    "viem": "^2.5.0",
+    "viem": "^2.9.2",
     "vitest": "^1.3.1",
     "wait-on": "^6.0.1"
   },
   "peerDependencies": {
-    "viem": "^2.5.0"
+    "viem": "^2.9.2"
   }
 }

--- a/packages/ensjs/src/functions/public/_getAbi.test.ts
+++ b/packages/ensjs/src/functions/public/_getAbi.test.ts
@@ -17,6 +17,6 @@ it('propagates error when strict is true', async () => {
     Params: (uint256, bytes)
     Data:   0x1234 (2 bytes)
 
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })

--- a/packages/ensjs/src/functions/public/_getAddr.test.ts
+++ b/packages/ensjs/src/functions/public/_getAddr.test.ts
@@ -17,6 +17,6 @@ it('propagates error when strict is true', async () => {
     Params: (address)
     Data:   0x1234 (2 bytes)
 
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })

--- a/packages/ensjs/src/functions/public/_getContentHash.test.ts
+++ b/packages/ensjs/src/functions/public/_getContentHash.test.ts
@@ -18,6 +18,6 @@ it('propagates error when strict is true', async () => {
     Params: (bytes)
     Data:   0x1234 (2 bytes)
 
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })

--- a/packages/ensjs/src/functions/public/_getText.test.ts
+++ b/packages/ensjs/src/functions/public/_getText.test.ts
@@ -17,6 +17,6 @@ it('propagates error when strict is true', async () => {
     Params: (string)
     Data:   0x1234 (2 bytes)
 
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })

--- a/packages/ensjs/src/functions/public/ccip.test.ts
+++ b/packages/ensjs/src/functions/public/ccip.test.ts
@@ -2,6 +2,7 @@ import { createPublicClient, http } from 'viem'
 import { goerli, mainnet } from 'viem/chains'
 import { describe, expect, it, vi } from 'vitest'
 import { addEnsContracts } from '../../contracts/addEnsContracts.js'
+import { ccipRequest } from '../../utils/ccipRequest.js'
 import batch from './batch.js'
 import getAddressRecord from './getAddressRecord.js'
 import getRecords from './getRecords.js'
@@ -25,6 +26,55 @@ describe('CCIP', () => {
   describe('getRecords', () => {
     it('should return records from a ccip-read name', async () => {
       const result = await getRecords(goerliPublicClient, {
+        name: '1.offchainexample.eth',
+        texts: ['email', 'description'],
+        contentHash: true,
+        coins: ['ltc', '60'],
+      })
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "coins": [
+            {
+              "id": 2,
+              "name": "ltc",
+              "value": "MQMcJhpWHYVeQArcZR3sBgyPZxxRtnH441",
+            },
+            {
+              "id": 60,
+              "name": "eth",
+              "value": "0x41563129cDbbD0c5D3e1c86cf9563926b243834d",
+            },
+          ],
+          "contentHash": {
+            "decoded": "bafybeico3uuyj3vphxpvbowchdwjlrlrh62awxscrnii7w7flu5z6fk77y",
+            "protocolType": "ipfs",
+          },
+          "resolverAddress": "0xEE28bdfBB91dE63bfBDA454082Bb1850f7804B09",
+          "texts": [
+            {
+              "key": "email",
+              "value": "nick@ens.domains",
+            },
+            {
+              "key": "description",
+              "value": "hello offchainresolver wildcard record",
+            },
+          ],
+        }
+      `)
+    })
+    it('should return records from a ccip-read name with custom ccipRequest', async () => {
+      const goerliWithEns = addEnsContracts(goerli)
+      const goerliPublicClientWithCustomCcipRequest = createPublicClient({
+        chain: goerliWithEns,
+        transport: http(
+          'https://goerli.gateway.tenderly.co/4imxc4hQfRjxrVB2kWKvTo',
+        ),
+        ccipRead: {
+          request: ccipRequest(goerliWithEns),
+        },
+      })
+      const result = await getRecords(goerliPublicClientWithCustomCcipRequest, {
         name: '1.offchainexample.eth',
         texts: ['email', 'description'],
         contentHash: true,

--- a/packages/ensjs/src/functions/public/getAbiRecord.test.ts
+++ b/packages/ensjs/src/functions/public/getAbiRecord.test.ts
@@ -261,7 +261,7 @@ describe('getAbiRecord()', () => {
         function:  resolve(bytes name, bytes data)
         args:             (0x, 0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/functions/public/getAddressRecord.test.ts
+++ b/packages/ensjs/src/functions/public/getAddressRecord.test.ts
@@ -121,7 +121,7 @@ describe('getAddressRecord()', () => {
         function:  resolve(bytes name, bytes data)
         args:             (0x, 0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/functions/public/getContentHashRecord.test.ts
+++ b/packages/ensjs/src/functions/public/getContentHashRecord.test.ts
@@ -67,7 +67,7 @@ describe('getContentHashRecord', () => {
         function:  resolve(bytes name, bytes data)
         args:             (0x, 0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/functions/public/getName.test.ts
+++ b/packages/ensjs/src/functions/public/getName.test.ts
@@ -119,7 +119,7 @@ describe('getName', () => {
         function:  reverse(bytes reverseName)
         args:             (0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
   it('should not return unnormalised name', async () => {

--- a/packages/ensjs/src/functions/public/getRecords.test.ts
+++ b/packages/ensjs/src/functions/public/getRecords.test.ts
@@ -146,7 +146,7 @@ describe('getRecords()', () => {
         args:             (0x04746573740365746800, ["0x5678"])
 
       Docs: https://viem.sh/docs/contract/decodeErrorResult
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/functions/public/getTextRecord.test.ts
+++ b/packages/ensjs/src/functions/public/getTextRecord.test.ts
@@ -58,7 +58,7 @@ describe('getTextRecord()', () => {
         function:  resolve(bytes name, bytes data)
         args:             (0x, 0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/functions/public/universalWrapper.test.ts
+++ b/packages/ensjs/src/functions/public/universalWrapper.test.ts
@@ -73,7 +73,7 @@ it('throws on result decode error when strict is true', async () => {
     Params: (bytes data, address resolver)
     Data:   0x1234 (2 bytes)
 
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })
 
@@ -116,7 +116,7 @@ it('throws on known contract error when strict is true', async () => {
     function:  resolve(bytes name, bytes data)
     args:             (0x, 0x)
 
-  Version: viem@2.5.0]
+  Version: viem@2.9.2]
 `)
 })
 
@@ -147,7 +147,7 @@ it('throws on unknown contract error when strict is false', async () => {
       args:             (0x, 0x)
 
     Docs: https://viem.sh/docs/contract/decodeErrorResult
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })
 
@@ -178,6 +178,6 @@ it('throws on unknown contract error when strict is true', async () => {
       args:             (0x, 0x)
 
     Docs: https://viem.sh/docs/contract/decodeErrorResult
-    Version: viem@2.5.0]
+    Version: viem@2.9.2]
   `)
 })

--- a/packages/ensjs/src/utils/ccipBatchRequest.test.ts
+++ b/packages/ensjs/src/utils/ccipBatchRequest.test.ts
@@ -1,0 +1,124 @@
+import type { RequestListener } from 'http'
+import { expect, it, vi } from 'vitest'
+import { createHttpServer } from '../test/createHttpServer.js'
+import { ccipBatchRequest } from './ccipBatchRequest.js'
+
+it('returns array of responses', async () => {
+  const handler = vi
+    .fn<Parameters<RequestListener>, ReturnType<RequestListener>>()
+    .mockImplementation((_, res) => {
+      res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/json',
+      })
+      res.end(JSON.stringify({ data: '0xdeadbeef' }))
+    })
+  const { close, url } = await createHttpServer(handler)
+  const items = [
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef01'],
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef02'],
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef03'],
+  ] as const
+  const result = await ccipBatchRequest(items)
+  expect(handler).toHaveBeenCalledTimes(3)
+  expect(result).toMatchInlineSnapshot(`
+    [
+      [
+        false,
+        false,
+        false,
+      ],
+      [
+        "0xdeadbeef",
+        "0xdeadbeef",
+        "0xdeadbeef",
+      ],
+    ]
+  `)
+  await close()
+})
+it('removes duplicate requests', async () => {
+  const handler = vi
+    .fn<Parameters<RequestListener>, ReturnType<RequestListener>>()
+    .mockImplementation((_, res) => {
+      res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/json',
+      })
+      res.end(JSON.stringify({ data: '0xdeadbeef' }))
+    })
+  const { close, url } = await createHttpServer(handler)
+  const items = [
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef'],
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef'],
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef'],
+  ] as const
+  const result = await ccipBatchRequest(items)
+  expect(handler).toHaveBeenCalledTimes(1)
+  expect(result).toMatchInlineSnapshot(`
+    [
+      [
+        false,
+        false,
+        false,
+      ],
+      [
+        "0xdeadbeef",
+        "0xdeadbeef",
+        "0xdeadbeef",
+      ],
+    ]
+  `)
+  await close()
+})
+it('handles and correctly returns HttpRequestError', async () => {
+  const handler = vi
+    .fn<Parameters<RequestListener>, ReturnType<RequestListener>>()
+    .mockImplementation((_, res) => {
+      res.writeHead(404)
+      res.end()
+    })
+  const { close, url } = await createHttpServer(handler)
+  const items = [
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef'],
+  ] as const
+  const result = await ccipBatchRequest(items)
+  expect(result).toMatchInlineSnapshot(`
+    [
+      [
+        true,
+      ],
+      [
+        "0xca7a4e750000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000194000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000094e6f7420466f756e640000000000000000000000000000000000000000000000",
+      ],
+    ]
+  `)
+  await close()
+})
+it('handles and correctly returns misc. error', async () => {
+  const handler = vi
+    .fn<Parameters<RequestListener>, ReturnType<RequestListener>>()
+    .mockImplementation((_, res) => {
+      res.writeHead(200, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/json',
+      })
+      res.end('invalid json')
+    })
+  const { close, url } = await createHttpServer(handler)
+  const items = [
+    ['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef'],
+  ] as const
+  const result = await ccipBatchRequest(items)
+  expect(result).toMatchInlineSnapshot(`
+    [
+      [
+        true,
+      ],
+      [
+        "0xca7a4e7500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001f400000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000028556e657870656374656420746f6b656e206920696e204a534f4e20617420706f736974696f6e2030000000000000000000000000000000000000000000000000",
+      ],
+    ]
+  `)
+  await close()
+})

--- a/packages/ensjs/src/utils/ccipBatchRequest.ts
+++ b/packages/ensjs/src/utils/ccipBatchRequest.ts
@@ -1,0 +1,93 @@
+import {
+  BaseError,
+  HttpRequestError,
+  ccipRequest,
+  encodeErrorResult,
+  parseAbi,
+  type Address,
+  type Hex,
+} from 'viem'
+
+type ReadonlyDeep<T> = {
+  readonly [P in keyof T]: ReadonlyDeep<T[P]>
+}
+
+const errorAbi = parseAbi(['error HttpError((uint16, string)[])'])
+
+type CcipRequestItem = [success: boolean, result: Hex]
+
+const ccipRequestItemHandler = async ([
+  wrappedSender,
+  wrappedUrls,
+  wrappedCallData,
+]: [Address, readonly string[], Hex]): Promise<CcipRequestItem> => {
+  try {
+    const ccipResult = await ccipRequest({
+      sender: wrappedSender,
+      urls: wrappedUrls,
+      data: wrappedCallData,
+    })
+    return [false, ccipResult]
+  } catch (e) {
+    if (e instanceof HttpRequestError) {
+      return [
+        true,
+        encodeErrorResult({
+          abi: errorAbi,
+          errorName: 'HttpError',
+          args: [[[e.status || 500, e.details]]],
+        }),
+      ]
+    }
+    return [
+      true,
+      encodeErrorResult({
+        abi: errorAbi,
+        errorName: 'HttpError',
+        args: [[[500, e instanceof BaseError ? e.details : 'Unknown Error']]],
+      }),
+    ]
+  }
+}
+
+export const ccipBatchRequest = async (
+  callDatas: ReadonlyDeep<[Address, string[], Hex][]>,
+) => {
+  const ccipRequestCache: Map<string, Promise<CcipRequestItem>> = new Map()
+  const responsePromises: Promise<CcipRequestItem>[] = []
+
+  for (let i = 0; i < callDatas.length; i += 1) {
+    const [wrappedSender, wrappedUrls, wrappedCallData] = callDatas[i]
+    const requestId = JSON.stringify([
+      wrappedSender,
+      wrappedUrls,
+      wrappedCallData,
+    ])
+
+    const existingRequest = ccipRequestCache.get(requestId)
+    if (existingRequest) {
+      responsePromises.push(existingRequest)
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    const ccipRequestPromise = ccipRequestItemHandler([
+      wrappedSender,
+      wrappedUrls,
+      wrappedCallData,
+    ])
+    ccipRequestCache.set(requestId, ccipRequestPromise)
+    responsePromises.push(ccipRequestPromise)
+  }
+
+  const awaitedResponses = await Promise.all(responsePromises)
+
+  return awaitedResponses.reduce(
+    ([failures, responses], [failure, response], i) => {
+      failures[i] = failure
+      responses[i] = response
+      return [failures, responses] as [failures: boolean[], responses: Hex[]]
+    },
+    [[], []] as [failures: boolean[], responses: Hex[]],
+  )
+}

--- a/packages/ensjs/src/utils/ccipRequest.test.ts
+++ b/packages/ensjs/src/utils/ccipRequest.test.ts
@@ -1,0 +1,72 @@
+import type { RequestListener } from 'http'
+import { encodeFunctionData, parseAbi } from 'viem'
+import { mainnet } from 'viem/chains'
+import { expect, it, vi } from 'vitest'
+import { getChainContractAddress } from '../contracts/getChainContractAddress.js'
+import { addEnsContracts } from '../index.js'
+import { createHttpServer } from '../test/createHttpServer.js'
+import { ccipRequest } from './ccipRequest.js'
+
+const handler = vi
+  .fn<Parameters<RequestListener>, ReturnType<RequestListener>>()
+  .mockImplementation((_, res) => {
+    res.writeHead(200, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'Content-Type': 'application/json',
+    })
+    res.end(JSON.stringify({ data: '0xdeadbeef' }))
+  })
+
+it('uses viemCcipRequest for standard request', async () => {
+  const { close, url } = await createHttpServer(handler)
+  const chain = addEnsContracts(mainnet)
+  const result = await ccipRequest(chain)({
+    sender: '0x8464135c8F25Da09e49BC8782676a84730C318bC',
+    urls: [url],
+    data: '0xdeadbeef',
+  })
+  expect(handler).toHaveBeenCalled()
+  expect(result).toEqual('0xdeadbeef')
+  await close()
+})
+it('uses viemCcipRequest for universalresolver request that is not matching signature', async () => {
+  const { close, url } = await createHttpServer(handler)
+  const chain = addEnsContracts(mainnet)
+  const result = await ccipRequest(chain)({
+    sender: getChainContractAddress({
+      client: { chain },
+      contract: 'ensUniversalResolver',
+    }),
+    urls: [url],
+    data: '0xdeadbeef',
+  })
+  expect(handler).toHaveBeenCalled()
+  expect(result).toEqual('0xdeadbeef')
+  await close()
+})
+it('uses ccipBatchRequest for universalresolver request that is matching signature', async () => {
+  const abi = parseAbi([
+    'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
+  ])
+  const { close, url } = await createHttpServer(handler)
+  const chain = addEnsContracts(mainnet)
+  const data = encodeFunctionData({
+    abi,
+    args: [
+      [['0x8464135c8F25Da09e49BC8782676a84730C318bC', [url], '0xdeadbeef']],
+    ],
+  })
+  const result = await ccipRequest(chain)({
+    sender: getChainContractAddress({
+      client: { chain },
+      contract: 'ensUniversalResolver',
+    }),
+    urls: ['https://example.com'],
+    data,
+  })
+  expect(handler).toHaveBeenCalled()
+  expect(result).toMatchInlineSnapshot(
+    `"0x0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000"`,
+  )
+  await close()
+})

--- a/packages/ensjs/src/utils/ccipRequest.ts
+++ b/packages/ensjs/src/utils/ccipRequest.ts
@@ -1,0 +1,44 @@
+import {
+  decodeFunctionData,
+  encodeFunctionResult,
+  isAddressEqual,
+  parseAbi,
+  ccipRequest as viemCcipRequest,
+  type CcipRequestParameters,
+  type Chain,
+} from 'viem'
+import { getChainContractAddress } from '../contracts/getChainContractAddress.js'
+import { ccipBatchRequest } from './ccipBatchRequest.js'
+
+const abi = parseAbi([
+  'function query((address,string[],bytes)[]) returns (bool[],bytes[])',
+])
+
+const universalResolverQuerySig = '0xa780bab6'
+
+export const ccipRequest =
+  <TChain extends Chain>(chain: TChain) =>
+  async ({
+    data,
+    sender,
+    urls,
+  }: CcipRequestParameters): ReturnType<typeof viemCcipRequest> => {
+    const universalResolverAddress = getChainContractAddress({
+      client: { chain },
+      contract: 'ensUniversalResolver',
+    })
+    const isUniversalResolverRequest = isAddressEqual(
+      sender,
+      universalResolverAddress,
+    )
+    if (
+      isUniversalResolverRequest &&
+      data.slice(0, 10) === universalResolverQuerySig
+    ) {
+      const { args } = decodeFunctionData({ abi, data })
+      const result = await ccipBatchRequest(args[0])
+      return encodeFunctionResult({ abi, result })
+    }
+
+    return viemCcipRequest({ data, sender, urls })
+  }

--- a/packages/ensjs/src/utils/checkSafeUniversalResolverData.test.ts
+++ b/packages/ensjs/src/utils/checkSafeUniversalResolverData.test.ts
@@ -69,7 +69,7 @@ describe('checkSafeUniversalResolverData', () => {
         function:  resolve(bytes name, bytes data)
         args:             (0x, 0x)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 
@@ -97,7 +97,7 @@ describe('checkSafeUniversalResolverData', () => {
         function:  resolve(bytes name, bytes data)
         args:             (ab, cd)
 
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 
@@ -129,7 +129,7 @@ describe('checkSafeUniversalResolverData', () => {
         args:             (0x, 0x)
 
       Docs: https://viem.sh/docs/contract/decodeErrorResult
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 
@@ -161,7 +161,7 @@ describe('checkSafeUniversalResolverData', () => {
         args:             (0x, 0x)
 
       Docs: https://viem.sh/docs/contract/decodeErrorResult
-      Version: viem@2.5.0]
+      Version: viem@2.9.2]
     `)
   })
 })

--- a/packages/ensjs/src/utils/index.ts
+++ b/packages/ensjs/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { ccipRequest } from './ccipRequest.js'
 export {
   getDnsTxtRecords,
   type GetDnsTxtRecordsParameters,
@@ -91,6 +92,7 @@ export {
   generateRecordCallArray,
   type RecordOptions,
 } from './generateRecordCallArray.js'
+export { generateSupportedContentTypes } from './generateSupportedContentTypes.js'
 export { bytesToPacket, packetToBytes } from './hexEncodedName.js'
 export {
   checkIsDecrypted,
@@ -145,4 +147,3 @@ export {
   expiryToBigInt,
   wrappedLabelLengthCheck,
 } from './wrapper.js'
-export { generateSupportedContentTypes } from './generateSupportedContentTypes.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,8 +251,8 @@ importers:
         specifier: 5.3.2
         version: 5.3.2
       viem:
-        specifier: ^2.5.0
-        version: 2.5.0(typescript@5.3.2)
+        specifier: ^2.9.2
+        version: 2.9.2(typescript@5.3.2)
       vitest:
         specifier: ^1.3.1
         version: 1.3.1(@types/node@20.3.3)(happy-dom@13.3.8)
@@ -9391,8 +9391,8 @@ packages:
       - zod
     dev: false
 
-  /viem@2.5.0(typescript@5.3.2):
-    resolution: {integrity: sha512-ytHXIWtlgPs4mcsGxXjJrQ25v+N4dE2hBzgCU8CVv4iXNh3PRFRgyYa7igZlmxiMVzkfSHHADOtivS980JhilA==}
+  /viem@2.9.2(typescript@5.3.2):
+    resolution: {integrity: sha512-GRakUTNiYE9W+vL+Be9JkQfzWnkczerHtSpEe2JR/jEGTYZAs4shrA4WLgiaVCI9JxpnduZhQfRWNvy2dlyP2g==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:


### PR DESCRIPTION
adds `ccipRequest` func which is exported from `/utils`

`ccipRequest` removes the universal-offchain-unwrapper requirement from the universal resolver contract, and replaces it with local logic that unwraps ccip-read requests.

can be used like so:
```ts
const chain = addEnsContracts(mainnet)
const publicClient = createPublicClient({
  chain,
  transport: http(),
  ccipRead: {
    request: ccipRequest(chain),
  },
})
```