### PR TITLE
migrate `setResolver`

### DIFF
--- a/packages/ensjs/src/actions/wallet/setResolver.test.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.test.ts
@@ -1,4 +1,4 @@
-import { zeroAddress, type Address, type Hex } from 'viem'
+import { type Address, type Hex, zeroAddress } from 'viem'
 import { afterEach, beforeAll, beforeEach, expect, it } from 'vitest'
 import {
   publicClient,

--- a/packages/ensjs/src/actions/wallet/setResolver.test.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.test.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex } from 'viem'
+import { zeroAddress, type Address, type Hex } from 'viem'
 import { afterEach, beforeAll, beforeEach, expect, it } from 'vitest'
 import {
   publicClient,
@@ -65,6 +65,18 @@ it('should error if unknown contract', async () => {
       account: accounts[1],
     }),
   ).rejects.toThrow('Unknown contract: random')
+})
+
+it.skip('should allow specifying a custom registry address', async () => {
+  const tx = await setResolver(walletClient, {
+    name: 'wrapped.eth',
+    registryAddress: zeroAddress,
+    resolverAddress: '0xAEfF4f4d8e2cB51854BEa2244B3C5Fb36b41C7fC',
+    account: accounts[1],
+  })
+  expect(tx).toBeTruthy()
+  const receipt = await waitForTransaction(tx)
+  expect(receipt.status).toBe('success')
 })
 
 // it('should return a transaction for a name and set successfully', async () => {

--- a/packages/ensjs/src/actions/wallet/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.ts
@@ -7,7 +7,7 @@ import type {
   WriteContractParameters,
   WriteContractReturnType,
 } from 'viem'
-import { labelhash, isAddress } from 'viem'
+import { isAddress, labelhash } from 'viem'
 import { writeContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import {
@@ -15,6 +15,7 @@ import {
   getChainContractAddress,
   type RequireClientContracts,
 } from '../../clients/chain.js'
+import { namechainSetResolverSnippet } from '../../contracts/namechain.js'
 import { nameWrapperSetResolverSnippet } from '../../contracts/nameWrapper.js'
 import { registrySetResolverSnippet } from '../../contracts/registry.js'
 import type { ErrorType } from '../../errors/utils.js'
@@ -25,7 +26,6 @@ import {
   clientWithOverrides,
 } from '../../utils/clientWithOverrides.js'
 import { type NamehashErrorType, namehash } from '../../utils/name/namehash.js'
-import { namechainSetResolverSnippet } from '../../contracts/namechain.js'
 
 export type SetResolverWriteParametersParameters = {
   /** Name to set resolver for */

--- a/packages/ensjs/src/actions/wallet/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.ts
@@ -69,7 +69,12 @@ export const setResolverWriteParameters = <
     'ensNameWrapper' | 'ensRegistry',
     account
   >,
-  { name, contract, resolverAddress, registryAddress }: SetResolverWriteParametersParameters,
+  {
+    name,
+    contract,
+    resolverAddress,
+    registryAddress,
+  }: SetResolverWriteParametersParameters,
 ) => {
   ASSERT_NO_TYPE_ERROR(client)
 

--- a/packages/ensjs/src/actions/wallet/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.ts
@@ -1,164 +1,150 @@
 import type {
-	Account,
-	Address,
-	Chain,
-	GetChainContractAddressErrorType,
-	WriteContractErrorType,
-	WriteContractParameters,
-	WriteContractReturnType,
-} from "viem";
-import { labelhash } from "viem";
-import { writeContract } from "viem/actions";
-import { getAction } from "viem/utils";
+  Account,
+  Address,
+  Chain,
+  GetChainContractAddressErrorType,
+  WriteContractErrorType,
+  WriteContractParameters,
+  WriteContractReturnType,
+} from 'viem'
+import { labelhash, isAddress } from 'viem'
+import { writeContract } from 'viem/actions'
+import { getAction } from 'viem/utils'
 import {
-	type ChainWithContracts,
-	getChainContractAddress,
-	type RequireClientContracts,
-} from "../../clients/chain.js";
-import { nameWrapperSetResolverSnippet } from "../../contracts/nameWrapper.js";
-import { registrySetResolverSnippet } from "../../contracts/registry.js";
-import type { ErrorType } from "../../errors/utils.js";
-import type {
-	Prettify,
-	WriteTransactionParameters,
-} from "../../types/index.js";
-import { ASSERT_NO_TYPE_ERROR } from "../../types/internal.js";
+  type ChainWithContracts,
+  getChainContractAddress,
+  type RequireClientContracts,
+} from '../../clients/chain.js'
+import { nameWrapperSetResolverSnippet } from '../../contracts/nameWrapper.js'
+import { registrySetResolverSnippet } from '../../contracts/registry.js'
+import type { ErrorType } from '../../errors/utils.js'
+import type { Prettify, WriteTransactionParameters } from '../../types/index.js'
+import { ASSERT_NO_TYPE_ERROR } from '../../types/internal.js'
 import {
-	type ClientWithOverridesErrorType,
-	clientWithOverrides,
-} from "../../utils/clientWithOverrides.js";
-import { type NamehashErrorType, namehash } from "../../utils/name/namehash.js";
+  type ClientWithOverridesErrorType,
+  clientWithOverrides,
+} from '../../utils/clientWithOverrides.js'
+import { type NamehashErrorType, namehash } from '../../utils/name/namehash.js'
+import { namechainSetResolverSnippet } from '../../contracts/namechain.js'
 
 export type SetResolverWriteParametersParameters = {
-	/** Name to set resolver for */
-	name: string;
-	/** Contract to set resolver on - can be 'registry', 'nameWrapper', or an address of a namechain registry */
-	contract: "registry" | "nameWrapper" | Address;
-	/** Resolver address to set */
-	resolverAddress: Address;
-};
+  /** Name to set resolver for */
+  name: string
+  /** Contract to set resolver on - can be 'registry', 'nameWrapper', or an address of a namechain registry */
+  contract: 'registry' | 'nameWrapper' | Address
+  /** Resolver address to set */
+  resolverAddress: Address
+}
 
 export type SetResolverWriteParametersReturnType = ReturnType<
-	typeof setResolverWriteParameters
->;
+  typeof setResolverWriteParameters
+>
 
 export type SetResolverWriteParametersErrorType =
-	| ErrorType
-	| GetChainContractAddressErrorType
-	| NamehashErrorType;
+  | ErrorType
+  | GetChainContractAddressErrorType
+  | NamehashErrorType
 
 // ================================
 // Write parameters
 // ================================
 
 export const setResolverWriteParameters = <
-	chain extends Chain,
-	account extends Account,
+  chain extends Chain,
+  account extends Account,
 >(
-	client: RequireClientContracts<
-		chain,
-		"ensNameWrapper" | "ensRegistry",
-		account
-	>,
-	{ name, contract, resolverAddress }: SetResolverWriteParametersParameters,
+  client: RequireClientContracts<
+    chain,
+    'ensNameWrapper' | 'ensRegistry',
+    account
+  >,
+  { name, contract, resolverAddress }: SetResolverWriteParametersParameters,
 ) => {
-	ASSERT_NO_TYPE_ERROR(client);
+  ASSERT_NO_TYPE_ERROR(client)
 
-	// Handle legacy contracts
-	if (contract === "registry" || contract === "nameWrapper") {
-		const address = getChainContractAddress({
-			chain: client.chain,
-			contract: contract === "nameWrapper" ? "ensNameWrapper" : "ensRegistry",
-		});
+  if (!isAddress(resolverAddress)) {
+    throw new Error(`Invalid resolver address: ${resolverAddress}`)
+  }
 
-		const args = [namehash(name), resolverAddress] as const;
-		const functionName = "setResolver";
+  // Handle legacy contracts
+  if (contract === 'registry' || contract === 'nameWrapper') {
+    const address = getChainContractAddress({
+      chain: client.chain,
+      contract: contract === 'nameWrapper' ? 'ensNameWrapper' : 'ensRegistry',
+    })
 
-		const baseParams = {
-			address,
-			functionName,
-			args,
-			chain: client.chain,
-			account: client.account,
-		} as const;
+    const args = [namehash(name), resolverAddress] as const
+    const functionName = 'setResolver'
 
-		if (contract === "nameWrapper")
-			return {
-				...baseParams,
-				abi: nameWrapperSetResolverSnippet,
-			} as const satisfies WriteContractParameters<
-				typeof nameWrapperSetResolverSnippet
-			>;
+    const baseParams = {
+      address,
+      functionName,
+      args,
+      chain: client.chain,
+      account: client.account,
+    } as const
 
-		return {
-			...baseParams,
-			abi: registrySetResolverSnippet,
-		} as const satisfies WriteContractParameters<
-			typeof registrySetResolverSnippet
-		>;
-	}
+    if (contract === 'nameWrapper')
+      return {
+        ...baseParams,
+        abi: nameWrapperSetResolverSnippet,
+      } as const satisfies WriteContractParameters<
+        typeof nameWrapperSetResolverSnippet
+      >
 
-	// Handle namechain contracts
-	const label = name.split(".")[0];
-	const tokenId = BigInt(labelhash(label));
+    return {
+      ...baseParams,
+      abi: registrySetResolverSnippet,
+    } as const satisfies WriteContractParameters<
+      typeof registrySetResolverSnippet
+    >
+  }
 
-	const args = [tokenId, resolverAddress] as const;
-	const functionName = "setResolver";
+  // Handle namechain contracts
+  if (!isAddress(contract)) {
+    throw new Error(`Invalid contract address: ${contract}`)
+  }
 
-	const baseParams = {
-		address: contract as Address,
-		functionName,
-		args,
-		chain: client.chain,
-		account: client.account,
-	} as const;
+  const label = name.split('.')[0]
+  const tokenId = BigInt(labelhash(label))
 
-	const namechainSetResolverSnippet = [
-		{
-			inputs: [
-				{
-					name: "tokenId",
-					type: "uint256",
-				},
-				{
-					name: "resolver",
-					type: "address",
-				},
-			],
-			name: "setResolver",
-			outputs: [],
-			stateMutability: "nonpayable",
-			type: "function",
-		},
-	] as const;
+  const args = [tokenId, resolverAddress] as const
 
-	return {
-		...baseParams,
-		abi: namechainSetResolverSnippet,
-	} as const satisfies WriteContractParameters<
-		typeof namechainSetResolverSnippet
-	>;
-};
+  const baseParams = {
+    address: contract as Address,
+    functionName: 'setResolver',
+    args,
+    chain: client.chain,
+    account: client.account,
+  } as const
+
+  return {
+    ...baseParams,
+    abi: namechainSetResolverSnippet,
+  } as const satisfies WriteContractParameters<
+    typeof namechainSetResolverSnippet
+  >
+}
 
 // ================================
 // Action
 // ================================
 
 export type SetResolverParameters<
-	chain extends Chain,
-	account extends Account,
-	chainOverride extends ChainWithContracts<"ensNameWrapper" | "ensRegistry">,
+  chain extends Chain,
+  account extends Account,
+  chainOverride extends ChainWithContracts<'ensNameWrapper' | 'ensRegistry'>,
 > = Prettify<
-	SetResolverWriteParametersParameters &
-		WriteTransactionParameters<chain, account, chainOverride>
->;
+  SetResolverWriteParametersParameters &
+    WriteTransactionParameters<chain, account, chainOverride>
+>
 
-export type SetResolverReturnType = WriteContractReturnType;
+export type SetResolverReturnType = WriteContractReturnType
 
 export type SetResolverErrorType =
-	| SetResolverWriteParametersErrorType
-	| ClientWithOverridesErrorType
-	| WriteContractErrorType;
+  | SetResolverWriteParametersErrorType
+  | ClientWithOverridesErrorType
+  | WriteContractErrorType
 
 /**
  * Sets a resolver for a name.
@@ -184,35 +170,35 @@ export type SetResolverErrorType =
  * // 0x...
  */
 export async function setResolver<
-	chain extends Chain,
-	account extends Account,
-	chainOverride extends ChainWithContracts<"ensNameWrapper" | "ensRegistry">,
+  chain extends Chain,
+  account extends Account,
+  chainOverride extends ChainWithContracts<'ensNameWrapper' | 'ensRegistry'>,
 >(
-	client: RequireClientContracts<
-		chain,
-		"ensNameWrapper" | "ensRegistry",
-		account
-	>,
-	{
-		name,
-		contract,
-		resolverAddress,
-		...txArgs
-	}: SetResolverParameters<chain, account, chainOverride>,
+  client: RequireClientContracts<
+    chain,
+    'ensNameWrapper' | 'ensRegistry',
+    account
+  >,
+  {
+    name,
+    contract,
+    resolverAddress,
+    ...txArgs
+  }: SetResolverParameters<chain, account, chainOverride>,
 ): Promise<SetResolverReturnType> {
-	ASSERT_NO_TYPE_ERROR(client);
+  ASSERT_NO_TYPE_ERROR(client)
 
-	const writeParameters = setResolverWriteParameters(
-		clientWithOverrides(client, txArgs),
-		{
-			name,
-			contract,
-			resolverAddress,
-		},
-	);
-	const writeContractAction = getAction(client, writeContract, "writeContract");
-	return writeContractAction({
-		...writeParameters,
-		...txArgs,
-	} as WriteContractParameters);
+  const writeParameters = setResolverWriteParameters(
+    clientWithOverrides(client, txArgs),
+    {
+      name,
+      contract,
+      resolverAddress,
+    },
+  )
+  const writeContractAction = getAction(client, writeContract, 'writeContract')
+  return writeContractAction({
+    ...writeParameters,
+    ...txArgs,
+  } as WriteContractParameters)
 }

--- a/packages/ensjs/src/actions/wallet/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.ts
@@ -1,119 +1,164 @@
 import type {
-  Account,
-  Address,
-  Chain,
-  GetChainContractAddressErrorType,
-  WriteContractErrorType,
-  WriteContractParameters,
-  WriteContractReturnType,
-} from 'viem'
-import { writeContract } from 'viem/actions'
-import { getAction } from 'viem/utils'
+	Account,
+	Address,
+	Chain,
+	GetChainContractAddressErrorType,
+	WriteContractErrorType,
+	WriteContractParameters,
+	WriteContractReturnType,
+} from "viem";
+import { labelhash } from "viem";
+import { writeContract } from "viem/actions";
+import { getAction } from "viem/utils";
 import {
-  type ChainWithContracts,
-  getChainContractAddress,
-  type RequireClientContracts,
-} from '../../clients/chain.js'
-import { nameWrapperSetResolverSnippet } from '../../contracts/nameWrapper.js'
-import { registrySetResolverSnippet } from '../../contracts/registry.js'
-import type { ErrorType } from '../../errors/utils.js'
-import type { Prettify, WriteTransactionParameters } from '../../types/index.js'
-import { ASSERT_NO_TYPE_ERROR } from '../../types/internal.js'
+	type ChainWithContracts,
+	getChainContractAddress,
+	type RequireClientContracts,
+} from "../../clients/chain.js";
+import { nameWrapperSetResolverSnippet } from "../../contracts/nameWrapper.js";
+import { registrySetResolverSnippet } from "../../contracts/registry.js";
+import type { ErrorType } from "../../errors/utils.js";
+import type {
+	Prettify,
+	WriteTransactionParameters,
+} from "../../types/index.js";
+import { ASSERT_NO_TYPE_ERROR } from "../../types/internal.js";
 import {
-  type ClientWithOverridesErrorType,
-  clientWithOverrides,
-} from '../../utils/clientWithOverrides.js'
-import { type NamehashErrorType, namehash } from '../../utils/name/namehash.js'
+	type ClientWithOverridesErrorType,
+	clientWithOverrides,
+} from "../../utils/clientWithOverrides.js";
+import { type NamehashErrorType, namehash } from "../../utils/name/namehash.js";
 
 export type SetResolverWriteParametersParameters = {
-  /** Name to set resolver for */
-  name: string
-  /** Contract to set resolver on */
-  contract: 'registry' | 'nameWrapper'
-  /** Resolver address to set */
-  resolverAddress: Address
-}
+	/** Name to set resolver for */
+	name: string;
+	/** Contract to set resolver on - can be 'registry', 'nameWrapper', or an address of a namechain registry */
+	contract: "registry" | "nameWrapper" | Address;
+	/** Resolver address to set */
+	resolverAddress: Address;
+};
 
 export type SetResolverWriteParametersReturnType = ReturnType<
-  typeof setResolverWriteParameters
->
+	typeof setResolverWriteParameters
+>;
 
 export type SetResolverWriteParametersErrorType =
-  | ErrorType
-  | GetChainContractAddressErrorType
-  | NamehashErrorType
+	| ErrorType
+	| GetChainContractAddressErrorType
+	| NamehashErrorType;
 
 // ================================
 // Write parameters
 // ================================
 
 export const setResolverWriteParameters = <
-  chain extends Chain,
-  account extends Account,
+	chain extends Chain,
+	account extends Account,
 >(
-  client: RequireClientContracts<
-    chain,
-    'ensNameWrapper' | 'ensRegistry',
-    account
-  >,
-  { name, contract, resolverAddress }: SetResolverWriteParametersParameters,
+	client: RequireClientContracts<
+		chain,
+		"ensNameWrapper" | "ensRegistry",
+		account
+	>,
+	{ name, contract, resolverAddress }: SetResolverWriteParametersParameters,
 ) => {
-  ASSERT_NO_TYPE_ERROR(client)
+	ASSERT_NO_TYPE_ERROR(client);
 
-  if (contract !== 'registry' && contract !== 'nameWrapper')
-    throw new Error(`Unknown contract: ${contract}`)
+	// Handle legacy contracts
+	if (contract === "registry" || contract === "nameWrapper") {
+		const address = getChainContractAddress({
+			chain: client.chain,
+			contract: contract === "nameWrapper" ? "ensNameWrapper" : "ensRegistry",
+		});
 
-  const address = getChainContractAddress({
-    chain: client.chain,
-    contract: contract === 'nameWrapper' ? 'ensNameWrapper' : 'ensRegistry',
-  })
+		const args = [namehash(name), resolverAddress] as const;
+		const functionName = "setResolver";
 
-  const args = [namehash(name), resolverAddress] as const
-  const functionName = 'setResolver'
+		const baseParams = {
+			address,
+			functionName,
+			args,
+			chain: client.chain,
+			account: client.account,
+		} as const;
 
-  const baseParams = {
-    address,
-    functionName,
-    args,
-    chain: client.chain,
-    account: client.account,
-  } as const
+		if (contract === "nameWrapper")
+			return {
+				...baseParams,
+				abi: nameWrapperSetResolverSnippet,
+			} as const satisfies WriteContractParameters<
+				typeof nameWrapperSetResolverSnippet
+			>;
 
-  if (contract === 'nameWrapper')
-    return {
-      ...baseParams,
-      abi: nameWrapperSetResolverSnippet,
-    } as const satisfies WriteContractParameters<
-      typeof nameWrapperSetResolverSnippet
-    >
+		return {
+			...baseParams,
+			abi: registrySetResolverSnippet,
+		} as const satisfies WriteContractParameters<
+			typeof registrySetResolverSnippet
+		>;
+	}
 
-  return {
-    ...baseParams,
-    abi: registrySetResolverSnippet,
-  } as const satisfies WriteContractParameters<
-    typeof registrySetResolverSnippet
-  >
-}
+	// Handle namechain contracts
+	const label = name.split(".")[0];
+	const tokenId = BigInt(labelhash(label));
+
+	const args = [tokenId, resolverAddress] as const;
+	const functionName = "setResolver";
+
+	const baseParams = {
+		address: contract as Address,
+		functionName,
+		args,
+		chain: client.chain,
+		account: client.account,
+	} as const;
+
+	const namechainSetResolverSnippet = [
+		{
+			inputs: [
+				{
+					name: "tokenId",
+					type: "uint256",
+				},
+				{
+					name: "resolver",
+					type: "address",
+				},
+			],
+			name: "setResolver",
+			outputs: [],
+			stateMutability: "nonpayable",
+			type: "function",
+		},
+	] as const;
+
+	return {
+		...baseParams,
+		abi: namechainSetResolverSnippet,
+	} as const satisfies WriteContractParameters<
+		typeof namechainSetResolverSnippet
+	>;
+};
 
 // ================================
 // Action
 // ================================
 
 export type SetResolverParameters<
-  chain extends Chain,
-  account extends Account,
-  chainOverride extends ChainWithContracts<'ensNameWrapper' | 'ensRegistry'>,
+	chain extends Chain,
+	account extends Account,
+	chainOverride extends ChainWithContracts<"ensNameWrapper" | "ensRegistry">,
 > = Prettify<
-  SetResolverWriteParametersParameters &
-    WriteTransactionParameters<chain, account, chainOverride>
->
+	SetResolverWriteParametersParameters &
+		WriteTransactionParameters<chain, account, chainOverride>
+>;
 
-export type SetResolverReturnType = WriteContractReturnType
+export type SetResolverReturnType = WriteContractReturnType;
 
 export type SetResolverErrorType =
-  | SetResolverWriteParametersErrorType
-  | ClientWithOverridesErrorType
-  | WriteContractErrorType
+	| SetResolverWriteParametersErrorType
+	| ClientWithOverridesErrorType
+	| WriteContractErrorType;
 
 /**
  * Sets a resolver for a name.
@@ -139,35 +184,35 @@ export type SetResolverErrorType =
  * // 0x...
  */
 export async function setResolver<
-  chain extends Chain,
-  account extends Account,
-  chainOverride extends ChainWithContracts<'ensNameWrapper' | 'ensRegistry'>,
+	chain extends Chain,
+	account extends Account,
+	chainOverride extends ChainWithContracts<"ensNameWrapper" | "ensRegistry">,
 >(
-  client: RequireClientContracts<
-    chain,
-    'ensNameWrapper' | 'ensRegistry',
-    account
-  >,
-  {
-    name,
-    contract,
-    resolverAddress,
-    ...txArgs
-  }: SetResolverParameters<chain, account, chainOverride>,
+	client: RequireClientContracts<
+		chain,
+		"ensNameWrapper" | "ensRegistry",
+		account
+	>,
+	{
+		name,
+		contract,
+		resolverAddress,
+		...txArgs
+	}: SetResolverParameters<chain, account, chainOverride>,
 ): Promise<SetResolverReturnType> {
-  ASSERT_NO_TYPE_ERROR(client)
+	ASSERT_NO_TYPE_ERROR(client);
 
-  const writeParameters = setResolverWriteParameters(
-    clientWithOverrides(client, txArgs),
-    {
-      name,
-      contract,
-      resolverAddress,
-    },
-  )
-  const writeContractAction = getAction(client, writeContract, 'writeContract')
-  return writeContractAction({
-    ...writeParameters,
-    ...txArgs,
-  } as WriteContractParameters)
+	const writeParameters = setResolverWriteParameters(
+		clientWithOverrides(client, txArgs),
+		{
+			name,
+			contract,
+			resolverAddress,
+		},
+	);
+	const writeContractAction = getAction(client, writeContract, "writeContract");
+	return writeContractAction({
+		...writeParameters,
+		...txArgs,
+	} as WriteContractParameters);
 }

--- a/packages/ensjs/src/actions/wallet/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/setResolver.ts
@@ -102,7 +102,7 @@ export const setResolverWriteParameters = <
 
   // Handle namechain contracts
   if (!isAddress(contract)) {
-    throw new Error(`Invalid contract address: ${contract}`)
+    throw new Error(`Unknown contract: ${contract}`)
   }
 
   const label = name.split('.')[0]

--- a/packages/ensjs/src/contracts/index.ts
+++ b/packages/ensjs/src/contracts/index.ts
@@ -46,7 +46,7 @@ export {
   multicallGetCurrentBlockTimestampSnippet,
   multicallTryAggregateSnippet,
 } from './multicall.js'
-export { namechainSetResolverSnippet } from './namechain.js'
+export { standardRegistrySetResolverSnippet } from './namechain/standardRegistry.js'
 export {
   nameWrapperErrors,
   nameWrapperGetDataSnippet,

--- a/packages/ensjs/src/contracts/index.ts
+++ b/packages/ensjs/src/contracts/index.ts
@@ -46,6 +46,7 @@ export {
   multicallGetCurrentBlockTimestampSnippet,
   multicallTryAggregateSnippet,
 } from './multicall.js'
+export { namechainSetResolverSnippet } from './namechain.js'
 export {
   nameWrapperErrors,
   nameWrapperGetDataSnippet,
@@ -96,4 +97,3 @@ export {
   universalResolverResolveSnippet,
   universalResolverReverseSnippet,
 } from './universalResolver.js'
-export { namechainSetResolverSnippet } from './namechain.js'

--- a/packages/ensjs/src/contracts/index.ts
+++ b/packages/ensjs/src/contracts/index.ts
@@ -96,3 +96,4 @@ export {
   universalResolverResolveSnippet,
   universalResolverReverseSnippet,
 } from './universalResolver.js'
+export { namechainSetResolverSnippet } from './namechain.js'

--- a/packages/ensjs/src/contracts/namechain.ts
+++ b/packages/ensjs/src/contracts/namechain.ts
@@ -1,0 +1,20 @@
+// Namechain contract ABI snippets
+
+export const namechainSetResolverSnippet = [
+  {
+    inputs: [
+      {
+        name: 'tokenId',
+        type: 'uint256',
+      },
+      {
+        name: 'resolver',
+        type: 'address',
+      },
+    ],
+    name: 'setResolver',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const

--- a/packages/ensjs/src/contracts/namechain/standardRegistry.ts
+++ b/packages/ensjs/src/contracts/namechain/standardRegistry.ts
@@ -1,6 +1,6 @@
 // Namechain contract ABI snippets
 
-export const namechainSetResolverSnippet = [
+export const standardRegistrySetResolverSnippet = [
   {
     inputs: [
       {


### PR DESCRIPTION
migrate `setResolver` to support namechain contracts while maintaining backwards compatibility.

the function now accepts registry addresses in addition to 'registry' and 'namewrapper' string literals.

for namechain contracts, it uses `labelhash` instead of `namehash` and calls `setResolver(tokenid, resolver)` with the appropriate abi.

should we extract the namechain abi snippet to a separate file like ../../contracts/namechain.js similar to how `nameWrapper` has? currently it's defined inline because its very simple.