### PR TITLE
refactor: use BigInt(labelhash(label)) instead of labelToCanonicalId …

### DIFF
--- a/packages/ensjs/src/actions/public/v2/getExpiry.ts
+++ b/packages/ensjs/src/actions/public/v2/getExpiry.ts
@@ -2,9 +2,8 @@ import { permissionedRegistryGetExpirySnippet } from '@ensdomains/ensjs-abi/v2/p
 import {
   type Address,
   type Chain,
-  keccak256,
+  labelhash,
   type ReadContractErrorType,
-  stringToBytes,
 } from 'viem'
 import { readContract } from 'viem/actions'
 import { type GetChainContractAddressErrorType, getAction } from 'viem/utils'
@@ -52,7 +51,7 @@ export async function getExpiry<chain extends Chain>(
       contract: 'ensRegistry',
     })
 
-  const labelHash = BigInt(keccak256(stringToBytes(labels[0])))
+  const labelHash = BigInt(labelhash(labels[0]))
 
   return readContractAction({
     address: currentRegistry,

--- a/packages/ensjs/src/actions/public/v2/getNameRolesAccounts.ts
+++ b/packages/ensjs/src/actions/public/v2/getNameRolesAccounts.ts
@@ -6,13 +6,14 @@ import {
   type Client,
   type GetLogsErrorType,
   type GetLogsParameters,
+  labelhash,
   zeroAddress,
 } from 'viem'
 import type { Address } from 'viem/accounts'
 import { getLogs, readContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId, registryRoles } from '../../../utils/v2/index.js'
+import { registryRoles } from '../../../utils/v2/index.js'
 import {
   decodeRoleCounts,
   type RoleName,
@@ -46,7 +47,7 @@ export async function getNameRoleAccounts(
   const readContractAction = getAction(client, readContract, 'readContract')
   const getLogsAction = getAction(client, getLogs, 'getLogs')
 
-  const labelHash = labelToCanonicalId(label)
+  const labelHash = BigInt(labelhash(label))
 
   const state = await readContractAction({
     address: registryAddress,

--- a/packages/ensjs/src/actions/public/v2/getNameRolesForAccount.ts
+++ b/packages/ensjs/src/actions/public/v2/getNameRolesForAccount.ts
@@ -1,11 +1,10 @@
 import { permissionedRegistryRolesSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import type { Client } from 'viem'
+import { type Client, labelhash } from 'viem'
 import type { Address } from 'viem/accounts'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
 import { decodeRoleCounts, registryRoles } from '../../../utils/v2/index.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 export type GetNameRolesForAccountParameters = {
   registryAddress: Address
@@ -54,7 +53,7 @@ export async function getNameRolesForAccount(
     address: registryAddress,
     abi: permissionedRegistryRolesSnippet,
     functionName: 'roles',
-    args: [labelToCanonicalId(label), account],
+    args: [BigInt(labelhash(label)), account],
   })
 
   const roleCounts = decodeRoleCounts(roleBitmap, registryRoles)

--- a/packages/ensjs/src/actions/public/v2/getOwner.ts
+++ b/packages/ensjs/src/actions/public/v2/getOwner.ts
@@ -1,9 +1,8 @@
 import { permissionedRegistryGetStateSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import type { Address, Client } from 'viem'
+import { type Address, type Client, labelhash } from 'viem'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 export type GetOwnerParameters = {
   registryAddress: Address
@@ -20,7 +19,7 @@ export async function getOwner(
 
   const readContractAction = getAction(client, readContract, 'readContract')
 
-  const labelHash = labelToCanonicalId(label)
+  const labelHash = BigInt(labelhash(label))
 
   const state = await readContractAction({
     address: registryAddress,

--- a/packages/ensjs/src/actions/public/v2/getRegistrationDate.ts
+++ b/packages/ensjs/src/actions/public/v2/getRegistrationDate.ts
@@ -4,9 +4,8 @@ import {
   type Chain,
   type GetBlockErrorType,
   type GetLogsErrorType,
-  keccak256,
+  labelhash,
   type ReadContractErrorType,
-  stringToBytes,
 } from 'viem'
 import { getBlock, getLogs, readContract } from 'viem/actions'
 import { type GetChainContractAddressErrorType, getAction } from 'viem/utils'
@@ -70,7 +69,7 @@ export async function getRegistrationDate<chain extends Chain>(
     address: registry,
     abi: permissionedRegistryGetTokenIdSnippet,
     functionName: 'getTokenId',
-    args: [BigInt(keccak256(stringToBytes(label)))],
+    args: [BigInt(labelhash(label))],
   })
 
   const logs = await getLogsAction({

--- a/packages/ensjs/src/actions/public/v2/getResource.ts
+++ b/packages/ensjs/src/actions/public/v2/getResource.ts
@@ -1,11 +1,10 @@
 import { permissionedRegistryGetResourceSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import type { Address, Chain } from 'viem'
+import { type Address, type Chain, labelhash } from 'viem'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
 import { type GetChainContractAddressErrorType, getAction } from 'viem/utils'
 import type { RequireClientContracts } from '../../../clients/shared.js'
 import { getChainContractAddress } from '../../../clients/shared.js'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 export type GetResourceParameters = {
   /** Label to get the EAC resource ID for */
@@ -41,7 +40,7 @@ export async function getResource<chain extends Chain>(
       contract: 'ensRegistry',
     })
 
-  const labelHash = labelToCanonicalId(label)
+  const labelHash = BigInt(labelhash(label))
 
   return readContractAction({
     address: currentRegistry,

--- a/packages/ensjs/src/actions/public/v2/getRoleCounts.ts
+++ b/packages/ensjs/src/actions/public/v2/getRoleCounts.ts
@@ -2,7 +2,7 @@ import { permissionedRegistryRoleCountSnippet } from '@ensdomains/ensjs-abi/v2/p
 import { type Client, labelhash } from 'viem'
 import type { Address } from 'viem/accounts'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
-import { getAction, hexToBigInt } from 'viem/utils'
+import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
 import {
   type DecodeRoleCountsReturnType,
@@ -52,7 +52,7 @@ export async function getRoleCounts(
     address: registryAddress,
     abi: permissionedRegistryRoleCountSnippet,
     functionName: 'roleCount',
-    args: [hexToBigInt(labelhash(label))],
+    args: [BigInt(labelhash(label))],
   })
 
   return {

--- a/packages/ensjs/src/actions/public/v2/getSubregistryHistory.ts
+++ b/packages/ensjs/src/actions/public/v2/getSubregistryHistory.ts
@@ -1,10 +1,14 @@
 import { subregistryUpdatedEventSnippet } from '@ensdomains/ensjs-abi/v2/userRegistry'
-import type { Client, GetLogsErrorType, GetLogsParameters } from 'viem'
+import {
+  type Client,
+  type GetLogsErrorType,
+  type GetLogsParameters,
+  labelhash,
+} from 'viem'
 import type { Address } from 'viem/accounts'
 import { getLogs } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 export type GetSubregistryHistoryParameters = {
   /** The registry address to query */
@@ -57,7 +61,7 @@ export async function getSubregistryHistory(
 
   const getLogsAction = getAction(client, getLogs, 'getLogs')
 
-  const tokenId = labelToCanonicalId(label)
+  const tokenId = BigInt(labelhash(label))
 
   const logs = await getLogsAction({
     address: registryAddress,

--- a/packages/ensjs/src/actions/public/v2/getTokenId.ts
+++ b/packages/ensjs/src/actions/public/v2/getTokenId.ts
@@ -1,11 +1,10 @@
 import { permissionedRegistryGetTokenIdSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import type { Address, Chain } from 'viem'
+import { type Address, type Chain, labelhash } from 'viem'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
 import { type GetChainContractAddressErrorType, getAction } from 'viem/utils'
 import type { RequireClientContracts } from '../../../clients/shared.js'
 import { getChainContractAddress } from '../../../clients/shared.js'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 export type GetTokenIdParameters = {
   /** Label to get the token ID for */
@@ -41,7 +40,7 @@ export async function getTokenId<chain extends Chain>(
       contract: 'ensRegistry',
     })
 
-  const labelHash = labelToCanonicalId(label)
+  const labelHash = BigInt(labelhash(label))
 
   return readContractAction({
     address: currentRegistry,

--- a/packages/ensjs/src/actions/public/v2/hasRoles.ts
+++ b/packages/ensjs/src/actions/public/v2/hasRoles.ts
@@ -3,11 +3,15 @@ import {
   permissionedResolverHasRolesSnippet,
   permissionedResolverHasRootRolesSnippet,
 } from '@ensdomains/ensjs-abi/v2/permissionedResolver'
-import type { Address, Client, ReadContractErrorType } from 'viem'
+import {
+  type Address,
+  type Client,
+  labelhash,
+  type ReadContractErrorType,
+} from 'viem'
 import { readContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 import {
   encodeRoleBitmap,
   type Role,
@@ -118,7 +122,7 @@ export async function hasRoles(
   // Registry mode: registryAddress + label
   if ('registryAddress' in params) {
     const { registryAddress, label, roles, account } = params
-    const resource = labelToCanonicalId(label)
+    const resource = BigInt(labelhash(label))
     const rolesBitmap = encodeRoleBitmap(roles)
 
     return readContractAction({

--- a/packages/ensjs/src/actions/wallet/v2/setResolver.ts
+++ b/packages/ensjs/src/actions/wallet/v2/setResolver.ts
@@ -9,10 +9,9 @@ import type {
   WriteContractErrorType,
   WriteContractParameters,
 } from 'viem'
-import { hexToBigInt } from 'viem'
+import { labelhash } from 'viem'
 import { writeContract } from 'viem/actions'
-import { packetToBytes } from 'viem/ens'
-import { getAction, toHex } from 'viem/utils'
+import { getAction } from 'viem/utils'
 import type {
   Prettify,
   WriteTransactionParameters,
@@ -28,8 +27,8 @@ import {
 // ================================
 
 export type SetResolverWriteParametersParameters = {
-  /** Name to set resolver for */
-  name: string
+  /** Label to set resolver for */
+  label: string
   /** The v2 registry address */
   registryAddress: Address
   /** Resolver address to set */
@@ -46,14 +45,14 @@ export const setResolverWriteParameters = <
 >(
   client: Client<Transport, chain, account>,
   {
-    name,
+    label,
     registryAddress,
     resolverAddress,
   }: SetResolverWriteParametersParameters,
 ) => {
   ASSERT_NO_TYPE_ERROR(client)
 
-  const tokenId = hexToBigInt(toHex(packetToBytes(name)))
+  const tokenId = BigInt(labelhash(label))
 
   return {
     address: registryAddress,
@@ -102,7 +101,7 @@ export type SetResolverErrorType =
  *   transport: custom(window.ethereum),
  * })
  * const hash = await setResolver(wallet, {
- *   name: 'myname.eth',
+ *   label: 'myname',
  *   registryAddress: '0x1234...', // v2 registry address
  *   resolverAddress: '0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41',
  * })
@@ -115,7 +114,7 @@ export async function setResolver<
 >(
   client: Client<Transport, chain, account>,
   {
-    name,
+    label,
     registryAddress,
     resolverAddress,
     ...txArgs
@@ -126,7 +125,7 @@ export async function setResolver<
   const writeParameters = setResolverWriteParameters(
     clientWithOverrides(client, txArgs),
     {
-      name,
+      label,
       registryAddress,
       resolverAddress,
     },

--- a/packages/ensjs/src/actions/wallet/v2/setSubregistry.ts
+++ b/packages/ensjs/src/actions/wallet/v2/setSubregistry.ts
@@ -9,6 +9,7 @@ import type {
   WriteContractErrorType,
   WriteContractParameters,
 } from 'viem'
+import { labelhash } from 'viem'
 import { writeContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import type {
@@ -20,7 +21,6 @@ import {
   type ClientWithOverridesErrorType,
   clientWithOverrides,
 } from '../../../utils/clientWithOverrides.js'
-import { labelToCanonicalId } from '../../../utils/v2/registry/labelToCanonicalId.js'
 
 // ================================
 // Write parameters
@@ -52,7 +52,7 @@ export const setSubregistryWriteParameters = <
 ) => {
   ASSERT_NO_TYPE_ERROR(client)
 
-  const tokenId = labelToCanonicalId(label)
+  const tokenId = BigInt(labelhash(label))
 
   return {
     address: registryAddress,


### PR DESCRIPTION
…in v2 actions

Since the contract's anyId parameter accepts raw labelhash values (the lower 32 bits are stripped internally by _entry()), there's no need to pre-zero them with labelToCanonicalId. Also normalizes keccak256+stringToBytes and hexToBigInt patterns to BigInt(labelhash()).

setResolver now accepts a label parameter instead of name.