### PR TITLE
fix(ensjs): use pnpm 11-compatible flags in updateVersion script

### DIFF
--- a/packages/ensjs/scripts/updateVersion.ts
+++ b/packages/ensjs/scripts/updateVersion.ts
@@ -7,7 +7,12 @@ const newVersion = process.argv[2]
 if (!newVersion) throw new Error('No version specified')
 
 // change version in package.json
-execSync(`pnpm version --no-workspaces-update ${newVersion}`, {
+// `--no-git-tag-version` skips the commit + tag that `pnpm version` would
+// otherwise make (release.yml does its own commit after this script writes
+// version.ts). `--no-git-checks` lets the bump run even if the working tree
+// has uncommitted changes. Non-recursive `pnpm version` only touches the
+// current package in pnpm 11, replacing the old `--no-workspaces-update`.
+execSync(`pnpm version --no-git-tag-version --no-git-checks ${newVersion}`, {
   stdio: 'inherit',
 })
 


### PR DESCRIPTION
pnpm 11 reimplemented `pnpm version` natively (no longer delegates to the npm CLI), and the previous `--no-workspaces-update` flag is gone. The new behavior is:

- non-recursive `pnpm version` only touches the current package, which is what `--no-workspaces-update` was doing
- by default it now creates a git commit + tag, which we don't want here because release.yml does its own commit after this script writes version.ts \u2014 use `--no-git-tag-version` to skip that
- `--no-git-checks` is added defensively so the bump still runs if the working tree is dirty when the script is invoked