### PR TITLE
chore: changeset for new Universal Resolver address

### DIFF
--- a/.changeset/swift-foxes-cheer.md
+++ b/.changeset/swift-foxes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ensdomains/ensjs": patch
+---
+
+Update Universal Resolver address and ABI to the new canonical deployment at `0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe` on mainnet and Sepolia (#262). The new UR adds extra error variants surfaced through `universalResolverErrors`; consumer code that already routes through `getRecords`, `getName`, etc. picks this up automatically.


### PR DESCRIPTION
## Summary

Adds a `patch` changeset for the Universal Resolver address + ABI update that landed in #262 ("Use new universal resolver"). That PR merged into `main` but didn't ship a changeset alongside it, so the next changesets-driven release run would otherwise skip the change in the changelog and not bump the `@ensdomains/ensjs` version.

### What's in the changeset

```md
---
"@ensdomains/ensjs": patch
---

Update Universal Resolver address and ABI to the new canonical deployment
at `0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe` on mainnet and Sepolia (#262).
The new UR adds extra error variants surfaced through `universalResolverErrors`;
consumer code that already routes through `getRecords`, `getName`, etc. picks
this up automatically.
```

### Why `patch`

No public TS API changed and `getRecords`/`getName`/etc. continue to work the same way for consumers. The change is internal (constant + ABI). Consumers running against mainnet or Sepolia will silently route through the new contract on upgrade, which is the desired behavior of the UR migration.

### Release flow

Once this PR merges to `main`, the changesets workflow in `publish.yml` will open a "[ci] release" PR that bumps `@ensdomains/ensjs` from `4.2.2` → `4.2.3` and prepends the message above to `CHANGELOG.md`. Merging that follow-up PR triggers the actual `npm publish` to `latest` via OIDC trusted publishing.

Note: the previous prerelease workflow (`release.yml`) and the `pnpm ver` script have been removed (see #330 / #331). Prereleases going forward should go through changesets pre-release mode (`pnpm chgset:version:prerelease`).
