### PR TITLE
fix(ci): use changeset publish so tags and GitHub releases auto-create

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,15 @@ jobs:
         with:
           # Note: pnpm install after versioning is necessary to refresh lockfile
           version: pnpm chgset:version
-          publish: pnpm publish -r --access public --provenance && changeset tag
+          # `changeset publish` shells out to `pnpm publish` under the hood
+          # (auto-detected from packageManager). Using it directly is what
+          # lets changesets/action parse the `🦋 New tag:` output and push
+          # git tags + create GitHub releases for each published package.
+          publish: pnpm exec changeset publish
           commit: "chore: release"
           title: "[ci] release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # changeset publish doesn't pass --provenance to the underlying
+          # `pnpm publish` invocation, so opt in via env (pnpm picks it up).
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

`@ensdomains/ensjs@4.2.3` ([release run #26649953097](https://github.com/ensdomains/ensjs/actions/runs/26649953097)) published to npm successfully but **no git tag was pushed and no GitHub release was created**. This PR fixes the workflow so future releases auto-tag and auto-release the way tinyhttp/tinyhttp does.

## Root cause

`changesets/action@v1` is responsible for pushing git tags and creating GitHub releases per published package. It does this by reading stdout from the `publish` step and parsing lines that match:

```ts
// changesets/action/src/run.ts
let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
```

That output format (`🦋 New tag: @scope/pkg@x.y.z`) is emitted by **`changeset publish`** from `@changesets/cli`. The previous `publish` script was:

```yaml
publish: pnpm publish -r --access public --provenance && changeset tag
```

Which emits pnpm's own output format (`📦 @scope/pkg@x.y.z → https://registry.npmjs.org/` / `✅ Published package @scope/pkg@x.y.z`) — that doesn't match the regex. So the action saw `releasedPackages = []`, skipped pushing tags, and skipped creating releases. `changeset tag` did create local tags on the runner, but the action only pushes tags inside its own `releasedPackages` loop.

Confirmed against tinyhttp/tinyhttp's working flow: their successful runs ([example](https://github.com/tinyhttp/tinyhttp/actions/runs/24465684525)) show `🦋 Creating git tags...` / `🦋 New tag: @tinyhttp/app@3.0.7` / `[command] /usr/bin/git push origin @tinyhttp/app@3.0.7` lines — all driven by the action because the publish step was `changeset publish`.

## Fix

Replace `pnpm publish -r ... && changeset tag` with `pnpm exec changeset publish`. Per the [changesets CLI docs](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish):

> This works by going into each package, checking if the version it has in its package.json is published on npm, and if it is not, running the npm publish. **If you are using pnpm as a package manager, this automatically detects it and uses pnpm publish instead.**

So no pnpm-specific behavior is lost. The only thing `changeset publish` doesn't forward to the underlying `pnpm publish` call is `--provenance` — for that we now set `NPM_CONFIG_PROVENANCE=true` as an env on the step, which pnpm reads the same way the `--provenance` flag would.

## Backfill

The missing `@ensdomains/ensjs@4.2.3` git tag and GitHub release have been created manually:

- Tag: `@ensdomains/ensjs@4.2.3` → main `a16be838` (the merge commit of the `[ci] release` PR #333)
- Release: https://github.com/ensdomains/ensjs/releases/tag/@ensdomains/ensjs@4.2.3

## Note on tag naming

Historical tags use `v4.2.x` (manually created by maintainers). `changesets/action`'s monorepo path uses `<pkg-name>@<version>` scoped tags. The backfill above uses the scoped form to match what the action will create going forward — so future releases (`4.2.4`, etc.) will keep producing `@ensdomains/ensjs@x.y.z` tags consistently.

## Verification

This will be verified the next time the release workflow runs end-to-end on a changeset-bearing PR. Manual smoke-test of the action's regex was done against the changesets/action source.
