### PR TITLE
feat: add adnl contenthash protocol

### DIFF
--- a/.changeset/adnl-contenthash.md
+++ b/.changeset/adnl-contenthash.md
@@ -1,0 +1,5 @@
+---
+"@ensdomains/ensjs": minor
+---
+
+Add adnl contenthash protocol

--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@adraffy/ens-normalize": "1.10.1",
     "@ensdomains/address-encoder": "1.1.3",
-    "@ensdomains/content-hash": "3.1.0-rc.1",
+    "@ensdomains/content-hash": "^3.1.1",
     "@ensdomains/dnsprovejs": "0.5.1",
     "abitype": "^1.0.0",
     "dns-packet": "^5.3.1",

--- a/packages/ensjs/src/utils/contentHash.test.ts
+++ b/packages/ensjs/src/utils/contentHash.test.ts
@@ -47,6 +47,12 @@ const arweave = {
     '0x90b2ca05cacdf63edf2e0bb4eb5711dd38b0723aca5f3c4ab62ceeb7c1110740833d4894',
 } as const
 
+const adnl = {
+  decoded: '61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5',
+  encoded:
+    '0x90b2da0561bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5',
+} as const
+
 const typeArray = [
   {
     type: 'ipfs',
@@ -75,6 +81,10 @@ const typeArray = [
   {
     type: 'ar',
     ...arweave,
+  },
+  {
+    type: 'adnl',
+    ...adnl,
   },
 ] as const
 

--- a/packages/ensjs/src/utils/contentHash.ts
+++ b/packages/ensjs/src/utils/contentHash.ts
@@ -15,6 +15,7 @@ export type ProtocolType =
   | 'onion3'
   | 'sia'
   | 'ar'
+  | 'adnl'
   | null
 
 export type DecodedContentHash = {
@@ -24,7 +25,7 @@ export type DecodedContentHash = {
 
 function matchProtocol(text: string) {
   return (
-    text.match(/^(ipfs|sia|ipns|bzz|onion|onion3|arweave|ar):\/\/(.*)/) ||
+    text.match(/^(ipfs|sia|ipns|bzz|onion|onion3|arweave|ar|adnl):\/\/(.*)/) ||
     text.match(/\/(ipfs)\/(.*)/) ||
     text.match(/\/(ipns)\/(.*)/)
   )
@@ -37,6 +38,7 @@ export const getDisplayCodec = (encoded: string): ProtocolType => {
     case 'ipns':
     case 'onion':
     case 'onion3':
+    case 'adnl':
       return codec
     case 'swarm':
       return 'bzz'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3
       '@ensdomains/content-hash':
-        specifier: 3.1.0-rc.1
-        version: 3.1.0-rc.1
+        specifier: ^3.1.1
+        version: 3.1.1
       '@ensdomains/dnsprovejs':
         specifier: 0.5.1
         version: 0.5.1(patch_hash=613f8e32e5cc6cd20878b81a100193aa6317ad42262f322cfd07dc6bf7027c22)
@@ -371,17 +371,15 @@ packages:
   '@ensdomains/address-encoder@0.1.9':
     resolution: {integrity: sha512-E2d2gP4uxJQnDu2Kfg1tHNspefzbLT8Tyjrm5sEuim32UkU2sm5xL4VXtgc2X33fmPEw9+jUMpGs4veMbf+PYg==}
 
-  '@ensdomains/address-encoder@1.0.0-rc.3':
-    resolution: {integrity: sha512-8o6zH69rObIqDY4PusEWuN9jvVOct+9jj9AOPO7ifc3ev8nmsly0e8TE1sHkhk0iKFbd3DlSsUnJ+yuRWmdLCQ==}
-
   '@ensdomains/address-encoder@1.1.3':
     resolution: {integrity: sha512-QS4ax0YkA8tsbQcWgBNmLLtb3aG0jsOQtED9SRyX9Ixflt1jDMuC/0i3ONMnNJNG5HTIko0Te4Y1JIGXjNcnUg==}
 
   '@ensdomains/buffer@0.1.3':
     resolution: {integrity: sha512-L/GoCkQFePjSn4DeVnBNfkGdm2CI8UxTxwgQztcZ1L9aHaFefRD+mTUXxtikk946KwwMHRQJDn38wo1IWtEpSg==}
 
-  '@ensdomains/content-hash@3.1.0-rc.1':
-    resolution: {integrity: sha512-OzdkXgdFmduzcJKU4KRkkJkQHnm5p7m7FkX8k+bHOEoOIzc0ueGT/Jay4nnb60wNk1wSHRmzY+hHBMpFDiGReg==}
+  '@ensdomains/content-hash@3.1.1':
+    resolution: {integrity: sha512-BKB3BtAtfDkSX3DOYsnnTlzAeM55bI0ze7UJhk8TzoxO5/4iHjgPoEHDzjgzCTYJoCOkpFPEDah+gl62e7HJjA==}
+    engines: {node: '>=18'}
 
   '@ensdomains/dnsprovejs@0.5.1':
     resolution: {integrity: sha512-nfm4ggpK5YBVwVwLZKF9WPjRGRTL9aUxX2O4pqv/AnQCz3WeGHsW7VhVFLj2s4EoWSzCXwR1E6nuqgUwnH692w==}
@@ -815,6 +813,9 @@ packages:
   '@metamask/utils@9.3.0':
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
+
+  '@multiformats/sha3@4.0.0':
+    resolution: {integrity: sha512-y/tB2RWyeIhUToaUIYkwZUtGqfGIa3kaTvAMVekvxWJUYaD7YLa7L6O8QYaOblxxc1MMobGwh63kS1NhocRQPw==}
 
   '@namestone/ezccip@0.1.1':
     resolution: {integrity: sha512-MZ0pLyAT695OfbXGIKNqHRHylIsk9KHMhpRP3ZgHVJxv5TZi1ouptylfEYr05qDqX33wYnR1w9BIqvcYcqruvA==}
@@ -3281,6 +3282,9 @@ packages:
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
+  js-sha3@0.9.3:
+    resolution: {integrity: sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3645,6 +3649,12 @@ packages:
   multiformats@12.1.3:
     resolution: {integrity: sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
+
+  multiformats@14.0.0:
+    resolution: {integrity: sha512-iWK1RrAS58p2NDfeZFuSUSv3ZPewTIhsGbh/5NgeGGJwJmRljLxGtjRR3nkn+loG3zl+IrfR/W1590QnrSK+Gg==}
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
@@ -5787,12 +5797,6 @@ snapshots:
       nano-base32: 1.0.1
       ripemd160: 2.0.2
 
-  '@ensdomains/address-encoder@1.0.0-rc.3':
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-
   '@ensdomains/address-encoder@1.1.3':
     dependencies:
       '@noble/curves': 1.9.1
@@ -5801,11 +5805,10 @@ snapshots:
 
   '@ensdomains/buffer@0.1.3': {}
 
-  '@ensdomains/content-hash@3.1.0-rc.1':
+  '@ensdomains/content-hash@3.1.1':
     dependencies:
-      '@ensdomains/address-encoder': 1.0.0-rc.3
-      '@noble/curves': 1.9.1
-      '@scure/base': 1.2.6
+      '@multiformats/sha3': 4.0.0
+      multiformats: 13.4.2
 
   '@ensdomains/dnsprovejs@0.5.1(patch_hash=613f8e32e5cc6cd20878b81a100193aa6317ad42262f322cfd07dc6bf7027c22)':
     dependencies:
@@ -6479,6 +6482,11 @@ snapshots:
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
+
+  '@multiformats/sha3@4.0.0':
+    dependencies:
+      js-sha3: 0.9.3
+      multiformats: 14.0.0
 
   '@namestone/ezccip@0.1.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
@@ -10005,6 +10013,8 @@ snapshots:
 
   js-sha3@0.8.0: {}
 
+  js-sha3@0.9.3: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -10357,6 +10367,10 @@ snapshots:
       varint: 5.0.2
 
   multiformats@12.1.3: {}
+
+  multiformats@13.4.2: {}
+
+  multiformats@14.0.0: {}
 
   multiformats@9.9.0: {}
 


### PR DESCRIPTION
Adds the `adnl` protocol (TON ADNL) to contenthash encode/decode.

The codec was registered as multicodec `0xb69910` and added in `@ensdomains/content-hash` 3.1.1, but ensjs still mapped it to `null`.

- `ProtocolType`: add `adnl`
- `getDisplayCodec` + `matchProtocol`: handle `adnl`
- bump `@ensdomains/content-hash` to `^3.1.1`

Tested with `tonnet.eth`'s on-chain contenthash.