### PR TITLE
feat(ensjs/getOwner): enhance getOwner function to return zero address for expired names

### DIFF
--- a/packages/ensjs/src/actions/public/v2/getOwner.test.ts
+++ b/packages/ensjs/src/actions/public/v2/getOwner.test.ts
@@ -1,10 +1,22 @@
+import type { Hex } from 'viem'
 import { zeroAddress } from 'viem'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   publicClient as client,
   deploymentAddresses,
+  testClient,
 } from '../../../test/addTestContracts.js'
 import { getOwner } from './getOwner.js'
+
+let snapshot: Hex
+
+beforeEach(async () => {
+  snapshot = await testClient.snapshot()
+})
+
+afterEach(async () => {
+  await testClient.revert({ id: snapshot })
+})
 
 describe('getOwner', () => {
   it('returns the owner address for a V2 name', async () => {
@@ -20,6 +32,20 @@ describe('getOwner', () => {
     const owner = await getOwner(client, {
       registryAddress: deploymentAddresses.ETHRegistry,
       label: 'thislabeldoesnotexistatall',
+    })
+
+    expect(owner).toEqual(zeroAddress)
+  })
+
+  it('returns zero address once the name has expired', async () => {
+    // `example` is registered for 1 year; warp past expiry + grace so the
+    // registry reports it AVAILABLE while still retaining `latestOwner`.
+    await testClient.increaseTime({ seconds: 400 * 24 * 60 * 60 })
+    await testClient.mine({ blocks: 1 })
+
+    const owner = await getOwner(client, {
+      registryAddress: deploymentAddresses.ETHRegistry,
+      label: 'example',
     })
 
     expect(owner).toEqual(zeroAddress)

--- a/packages/ensjs/src/actions/public/v2/getOwner.ts
+++ b/packages/ensjs/src/actions/public/v2/getOwner.ts
@@ -1,5 +1,5 @@
 import { permissionedRegistryGetStateSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import { type Address, type Client, labelhash } from 'viem'
+import { type Address, type Client, labelhash, zeroAddress } from 'viem'
 import { type ReadContractErrorType, readContract } from 'viem/actions'
 import { getAction } from 'viem/utils'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
@@ -11,6 +11,25 @@ export type GetOwnerParameters = {
 
 export type GetOwnerErrorType = ReadContractErrorType
 
+// IPermissionedRegistry.Status (see contracts-v2 `PermissionedRegistry.sol`):
+//   AVAILABLE = 0, RESERVED = 1, REGISTERED = 2
+// A label is only currently owned when REGISTERED. Once expired the registry
+// reports AVAILABLE — but it deliberately keeps `latestOwner` pointing at the
+// lapsed holder (used for grace-period renewals / history), so reading that
+// field directly would report an expired name as still owned.
+const STATUS_REGISTERED = 2
+
+/**
+ * Gets the current owner of a name from a V2 registry.
+ *
+ * Mirrors the registry's `ownerOf`: returns the zero address once the name has
+ * expired (or was never registered). The registry retains `latestOwner` after
+ * expiry, so we gate on the registration status rather than returning the stale
+ * holder — see {@link STATUS_REGISTERED}.
+ * @param client - {@link Client}
+ * @param parameters - {@link GetOwnerParameters}
+ * @returns Owner address, or the zero address if the name has no current owner.
+ */
 export async function getOwner(
   client: Client,
   { registryAddress, label }: GetOwnerParameters,
@@ -28,5 +47,5 @@ export async function getOwner(
     args: [labelHash],
   })
 
-  return state.latestOwner
+  return state.status === STATUS_REGISTERED ? state.latestOwner : zeroAddress
 }


### PR DESCRIPTION


- Added logic to return zero address when a name has expired, aligning with the registry's behavior.
- Updated tests to verify the new functionality, including a case for names that have surpassed their registration period.
- Introduced snapshot management in tests to ensure state consistency across test runs.