### PR TITLE
fix(ensjs): enforce normalization on getName returned name

### DIFF
--- a/.changeset/getname-normalize-mismatch.md
+++ b/.changeset/getname-normalize-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@ensdomains/ensjs": patch
+---
+
+`getName` now normalizes the returned name in the forward/reverse mismatch path (`allowMismatch: true`). Previously the name surfaced from a `ReverseAddressMismatch` was returned unnormalized, making normalization inconsistent with the matching path which already normalizes. All names returned from `getName` are now normalized via `@adraffy/ens-normalize` (WEB-533).

--- a/packages/ensjs/src/functions/public/getName.test.ts
+++ b/packages/ensjs/src/functions/public/getName.test.ts
@@ -150,6 +150,35 @@ describe('getName', () => {
       Version: viem@2.37.12]
     `)
   })
+  it('should return a normalised name in the mismatch path', async () => {
+    const result = await getName.decode(
+      {} as ClientWithEns,
+      new RawContractError({
+        data: encodeErrorResult({
+          abi: universalResolverErrors,
+          errorName: 'ReverseAddressMismatch',
+          args: ['Nick.eth', accounts[0]],
+        }),
+      }),
+      {
+        address: '0x1234567890abcdef',
+        args: ['0x', 60n],
+      },
+      {
+        address: accounts[0],
+        allowMismatch: true,
+        strict: false,
+      },
+    )
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "match": false,
+        "name": "nick.eth",
+        "resolverAddress": "0x0000000000000000000000000000000000000000",
+        "reverseResolverAddress": "0x0000000000000000000000000000000000000000",
+      }
+    `)
+  })
   it('should not return unnormalised name', async () => {
     const tx1 = await createSubname(walletClient, {
       name: 'suB.with-profile.eth',

--- a/packages/ensjs/src/functions/public/getName.ts
+++ b/packages/ensjs/src/functions/public/getName.ts
@@ -135,7 +135,7 @@ const decode = async (
       })
       if (decodedError.errorName !== 'ReverseAddressMismatch') return null
       return {
-        name: decodedError.args[0],
+        name: normalise(decodedError.args[0]),
         match: false,
         reverseResolverAddress: zeroAddress,
         resolverAddress: zeroAddress,


### PR DESCRIPTION
## Summary

`getName` should always return a normalized name. The matching path (`match: true`) already normalizes via `@adraffy/ens-normalize`, but the forward/reverse **mismatch** path (`allowMismatch: true`, surfaced from a `ReverseAddressMismatch` error) returned the name unnormalized.

This wraps that name in `normalise(...)` so normalization is enforced consistently across both return paths.

Closes [WEB-533](https://linear.app/enslabs/issue/WEB-533/ensjs-v4-getname-should-enforce-normalization).

## Changes
- `getName.ts`: normalize the name in the `ReverseAddressMismatch` path.
- `getName.test.ts`: add a test asserting the mismatch path returns a normalized name (`Nick.eth` -> `nick.eth`).
- Added a patch changeset.

## Notes
- If a mismatch name fails to normalize, it falls into the existing `try/catch` and returns `null`, consistent with the rest of `decode`.