### PR TITLE
fix(ensjs): getName should enforce normalization

### DIFF
--- a/.changeset/getname-enforce-normalization.md
+++ b/.changeset/getname-enforce-normalization.md
@@ -1,0 +1,5 @@
+---
+"@ensdomains/ensjs": patch
+---
+
+`getName` now enforces normalization: it only returns a primary name if the value returned by reverse resolution is already in its normalised form, returning `null` otherwise (instead of silently coercing it). This mirrors viem's `getEnsName` behaviour (wevm/viem#4756) and brings v4 in line with v5 (WEB-533). The normalization check is applied to both the matching and `allowMismatch` paths.

--- a/packages/ensjs/src/functions/public/getName.test.ts
+++ b/packages/ensjs/src/functions/public/getName.test.ts
@@ -4,10 +4,15 @@ import {
   RawContractError,
   bytesToHex,
   encodeErrorResult,
+  encodeFunctionResult,
+  zeroAddress,
 } from 'viem'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import type { ClientWithEns } from '../../contracts/consts.js'
-import { universalResolverErrors } from '../../contracts/universalResolver.js'
+import {
+  universalResolverErrors,
+  universalResolverReverseSnippet,
+} from '../../contracts/universalResolver.js'
 import {
   deploymentAddresses,
   publicClient,
@@ -149,6 +154,66 @@ describe('getName', () => {
 
       Version: viem@2.37.12]
     `)
+  })
+  it('should return null for an unnormalised name in the match path', async () => {
+    const result = await getName.decode(
+      {} as ClientWithEns,
+      encodeFunctionResult({
+        abi: universalResolverReverseSnippet,
+        functionName: 'reverse',
+        result: ['Nick.eth', zeroAddress, zeroAddress],
+      }),
+      {
+        address: '0x1234567890abcdef',
+        args: ['0x', 60n],
+      },
+      {
+        address: accounts[0],
+        strict: false,
+      },
+    )
+    expect(result).toBeNull()
+  })
+  it('should return a normalised match unchanged', async () => {
+    const result = await getName.decode(
+      {} as ClientWithEns,
+      encodeFunctionResult({
+        abi: universalResolverReverseSnippet,
+        functionName: 'reverse',
+        result: ['nick.eth', zeroAddress, zeroAddress],
+      }),
+      {
+        address: '0x1234567890abcdef',
+        args: ['0x', 60n],
+      },
+      {
+        address: accounts[0],
+        strict: false,
+      },
+    )
+    expect(result).toMatchObject({ name: 'nick.eth', match: true })
+  })
+  it('should return null for an unnormalised name in the mismatch path', async () => {
+    const result = await getName.decode(
+      {} as ClientWithEns,
+      new RawContractError({
+        data: encodeErrorResult({
+          abi: universalResolverErrors,
+          errorName: 'ReverseAddressMismatch',
+          args: ['Nick.eth', accounts[0]],
+        }),
+      }),
+      {
+        address: '0x1234567890abcdef',
+        args: ['0x', 60n],
+      },
+      {
+        address: accounts[0],
+        allowMismatch: true,
+        strict: false,
+      },
+    )
+    expect(result).toBeNull()
   })
   it('should not return unnormalised name', async () => {
     const tx1 = await createSubname(walletClient, {

--- a/packages/ensjs/src/functions/public/getName.ts
+++ b/packages/ensjs/src/functions/public/getName.ts
@@ -8,6 +8,7 @@ import {
   encodeFunctionData,
   zeroAddress,
 } from 'viem'
+import { normalize } from 'viem/ens'
 import type { ClientWithEns } from '../../contracts/consts.js'
 import { getChainContractAddress } from '../../contracts/getChainContractAddress.js'
 import {
@@ -24,7 +25,21 @@ import {
   generateFunction,
 } from '../../utils/generateFunction.js'
 import { getRevertErrorData } from '../../utils/getRevertErrorData.js'
-import { normalise } from '../../utils/normalise.js'
+
+/**
+ * Checks whether a name is already normalised, without coercing it.
+ *
+ * Mirrors viem's `getEnsName` normalization enforcement (wevm/viem#4756):
+ * a name is only returned if it is already in its normalised form. Returns
+ * `false` if the name cannot be normalised (i.e. `normalize` throws).
+ */
+const isNormalised = (name: string): boolean => {
+  try {
+    return name === normalize(name)
+  } catch {
+    return false
+  }
+}
 
 type GetNameCoinTypeParameters = {
   coinType: number
@@ -134,8 +149,10 @@ const decode = async (
         data: errorData,
       })
       if (decodedError.errorName !== 'ReverseAddressMismatch') return null
+      const [name] = decodedError.args
+      if (!isNormalised(name)) return null
       return {
-        name: decodedError.args[0],
+        name,
         match: false,
         reverseResolverAddress: zeroAddress,
         resolverAddress: zeroAddress,
@@ -155,9 +172,9 @@ const decode = async (
 
     if (!unnormalisedName) return null
 
-    const normalisedName = normalise(unnormalisedName)
+    if (!isNormalised(unnormalisedName)) return null
     return {
-      name: normalisedName,
+      name: unnormalisedName,
       match: true,
       reverseResolverAddress,
       resolverAddress,


### PR DESCRIPTION
## Summary

ENSjs v4 `getName` previously **coerced** the reverse-resolved name with `normalise()`, silently returning a name that differs from what reverse resolution actually returned. It now **enforces** normalization the same way viem's `getEnsName` does ([wevm/viem#4756](https://github.com/wevm/viem/pull/4756)) and the same way ENSjs v5 already does: the name is returned only if it is **already** normalised, otherwise `getName` returns `null`.

Uses viem's `normalize` (`viem/ens`) under the hood for the check.

Closes [WEB-533](https://linear.app/enslabs/issue/WEB-533/ensjs-v4-getname-should-enforce-normalization).

## Changes
- `getName.ts`:
  - Add an `isNormalised` helper using viem's `normalize` (returns `false` if `normalize` throws).
  - Replace coercion with a normalization **match check** in the success path (return raw name, or `null`).
  - Apply the same check in the `ReverseAddressMismatch` (`allowMismatch: true`) path.
- `getName.test.ts`: add unit tests for both paths (unnormalised -> `null`, normalised -> unchanged).
- Added a patch changeset.

## Notes / design
- Kept the existing `encode`/`decode` (`generateFunction`) architecture so `getName.batch()` and ENSjs's on-chain `batch()` multicall continue to work, and the return body (`{ name, match, reverseResolverAddress, resolverAddress }`) is unchanged.
- viem's `getEnsName` itself was not used directly because it returns only `string | null` and is a monolithic action (no `encode`/`decode`), which would drop the `match`/resolver-address fields and break batching.