### PR TITLE
feat(ensjs/getAvailable): support .eth subnames of any depth

### DIFF
--- a/packages/ensjs-abi/src/universalResolver.ts
+++ b/packages/ensjs-abi/src/universalResolver.ts
@@ -219,6 +219,46 @@ export const universalResolverFindResolverSnippet = [
   },
 ] as const
 
+export const universalResolverV2FindOwnerSnippet = [
+  {
+    inputs: [
+      {
+        name: 'name',
+        type: 'bytes',
+      },
+    ],
+    name: 'findOwner',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+export const universalResolverV2FindParentRegistrySnippet = [
+  {
+    inputs: [
+      {
+        name: 'name',
+        type: 'bytes',
+      },
+    ],
+    name: 'findParentRegistry',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
 export const universalResolverFindRegistriesSnippet = [
   ...universalResolverErrors,
   {

--- a/packages/ensjs-abi/src/v2/permissionedRegistry.ts
+++ b/packages/ensjs-abi/src/v2/permissionedRegistry.ts
@@ -20,6 +20,16 @@ export const permissionedRegistryGetStateSnippet = [
   },
 ] as const
 
+export const permissionedRegistryGetStatusSnippet = [
+  {
+    type: 'function',
+    name: 'getStatus',
+    inputs: [{ name: 'anyId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'uint8' }],
+    stateMutability: 'view',
+  },
+] as const
+
 export const permissionedRegistryGetResolverSnippet = [
   {
     type: 'function',

--- a/packages/ensjs/package.json
+++ b/packages/ensjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/ensjs",
-  "version": "0.0.0-remove-deploy-scripts.20260626T185524279",
+  "version": "5.0.0-alpha.1",
   "description": "ENS javascript library for contract interaction",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/ensjs/src/actions/public/v2/getAvailable.test.ts
+++ b/packages/ensjs/src/actions/public/v2/getAvailable.test.ts
@@ -1,19 +1,86 @@
 import { describe, expect, it } from 'vitest'
+import { UnsupportedNameTypeError } from '../../../errors/general.js'
 import { publicClient as publicClientL2 } from '../../../test/addTestContracts.js'
 import { getAvailable } from './getAvailable.js'
 
 describe('getAvailable', () => {
-  it('should return false for a name that is unavailable', async () => {
-    // 'test' is pre-seeded by the devnet's --testNames
-    const result = await getAvailable(publicClientL2, { name: 'test.eth' })
-    expect(typeof result).toBe('boolean')
-    expect(result).toBe(false)
-  })
-  it('should return true for a name that is available', async () => {
-    const result = await getAvailable(publicClientL2, {
-      name: 'available-name.eth',
+  describe('eth-2ld', () => {
+    it('should return false for a registered name', async () => {
+      // `test.eth` is registered by the devnet's --testNames
+      const result = await getAvailable(publicClientL2, { name: 'test.eth' })
+      expect(result).toBe(false)
     })
-    expect(typeof result).toBe('boolean')
-    expect(result).toBe(true)
+
+    it('should return true for an unregistered name', async () => {
+      const result = await getAvailable(publicClientL2, {
+        name: 'available-name.eth',
+      })
+      expect(result).toBe(true)
+    })
+
+    it('should return false for a RESERVED name', async () => {
+      // `reserved.eth` is reserved (no owner, no token) by the devnet.
+      // The registrar's isAvailable must treat reserved names as unavailable.
+      const result = await getAvailable(publicClientL2, {
+        name: 'reserved.eth',
+      })
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('eth-subname (3LD and beyond)', () => {
+    it('should return false for a registered subname', async () => {
+      const result = await getAvailable(publicClientL2, {
+        name: 'sub2.parent.eth',
+      })
+      expect(result).toBe(false)
+    })
+
+    it('should return true for an available subname', async () => {
+      const result = await getAvailable(publicClientL2, {
+        name: 'definitely-available-sub.parent.eth',
+      })
+      expect(result).toBe(true)
+    })
+
+    it('should return false for a registered 3LD (sub1.sub2.parent.eth)', async () => {
+      const result = await getAvailable(publicClientL2, {
+        name: 'sub1.sub2.parent.eth',
+      })
+      expect(result).toBe(false)
+    })
+
+    it('should return false for a registered 4LD (wallet.sub1.sub2.parent.eth)', async () => {
+      const result = await getAvailable(publicClientL2, {
+        name: 'wallet.sub1.sub2.parent.eth',
+      })
+      expect(result).toBe(false)
+    })
+
+    it('should return true for a deep available subname under an existing parent', async () => {
+      // `available.sub1.sub2.parent.eth` is not registered, but its parent
+      // registry (sub1.sub2.parent.eth) exists.
+      const result = await getAvailable(publicClientL2, {
+        name: 'available.sub1.sub2.parent.eth',
+      })
+      expect(result).toBe(true)
+    })
+
+    it('should return true for a subname under a parent with no subregistry', async () => {
+      // `test.eth` has no subregistry, so any subname under it is available.
+      const result = await getAvailable(publicClientL2, {
+        name: 'anything.test.eth',
+      })
+      expect(result).toBe(true)
+    })
+  })
+
+  it('should throw for unsupported name types', async () => {
+    // DNS 2LD, DNS subname, eth tld, non-eth tld, and root
+    for (const name of ['example.com', 'sub.example.com', 'eth', 'com', '']) {
+      await expect(getAvailable(publicClientL2, { name })).rejects.toThrowError(
+        UnsupportedNameTypeError,
+      )
+    }
   })
 })

--- a/packages/ensjs/src/actions/public/v2/getAvailable.ts
+++ b/packages/ensjs/src/actions/public/v2/getAvailable.ts
@@ -1,10 +1,14 @@
+import { universalResolverV2FindParentRegistrySnippet } from '@ensdomains/ensjs-abi/universalResolver'
 import { ethRegistrarAvailableSnippet } from '@ensdomains/ensjs-abi/v2/ethRegistrar'
+import { permissionedRegistryGetStatusSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
 import type {
   Chain,
   GetChainContractAddressErrorType,
   ReadContractErrorType,
 } from 'viem'
+import { labelhash, toHex, zeroAddress } from 'viem'
 import { readContract } from 'viem/actions'
+import { packetToBytes } from 'viem/ens'
 import { getAction } from 'viem/utils'
 import type { RequireClientContracts } from '../../../clients/shared.js'
 import { getChainContractAddress } from '../../../clients/shared.js'
@@ -14,7 +18,14 @@ import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
 import { getNameType } from '../../../utils/name/getNameType.js'
 
 export type GetAvailableParameters = {
-  /** Name to check availability for, only compatible for eth 2ld */
+  /**
+   * Name to check availability for. Only `.eth` names are supported:
+   * - `eth-2ld` names (e.g. `name.eth`)
+   * - `eth-subname` names of any depth (e.g. `sub.name.eth`)
+   *
+   * DNS names are not supported (they have both on-chain and off-chain
+   * import paths, so a single availability answer would be ambiguous).
+   */
   name: string
 }
 
@@ -27,7 +38,15 @@ export type GetAvailableErrorType =
   | ErrorType
 
 /**
- * Gets the availability of a name to register
+ * Gets the availability of a `.eth` name to register.
+ *
+ * For `eth-2ld` names, availability is read from the `.eth` registrar via
+ * `isAvailable`, which accounts for grace periods and premium decay.
+ *
+ * For `eth-subname` names, the Universal Resolver V2's `findParentRegistry`
+ * is used to traverse the registry tree and locate the parent registry, then
+ * the leaf label's status is checked against it.
+ *
  * @param client - {@link Client}
  * @param parameters - {@link GetAvailableParameters}
  * @returns Availability as boolean. {@link GetAvailableReturnType}
@@ -42,33 +61,68 @@ export type GetAvailableErrorType =
  *   chain: addEnsContracts(mainnet),
  *   transport: http(),
  * })
- * const result = await getAvailable(client, { name: 'ens.eth' })
+ *
+ * // eth-2ld via the .eth registrar
+ * const a = await getAvailable(client, { name: 'ens.eth' })
  * // false
+ *
+ * // eth-subname with auto-traversal via Universal Resolver
+ * const b = await getAvailable(client, { name: 'sub.ens.eth' })
  */
 export async function getAvailable<chain extends Chain>(
-  client: RequireClientContracts<chain, 'ensEthRegistrar'>,
+  client: RequireClientContracts<
+    chain,
+    'ensEthRegistrar' | 'ensUniversalResolver'
+  >,
   { name }: GetAvailableParameters,
 ): Promise<GetAvailableReturnType> {
+  ASSERT_NO_TYPE_ERROR(client)
+
   const labels = name.split('.')
   const nameType = getNameType(name)
-  ASSERT_NO_TYPE_ERROR(client)
-  if (nameType !== 'eth-2ld')
+
+  if (nameType !== 'eth-2ld' && nameType !== 'eth-subname')
     throw new UnsupportedNameTypeError({
       nameType,
-      supportedNameTypes: ['eth-2ld'],
-      details: 'Currently only eth-2ld names can be checked for availability',
+      supportedNameTypes: ['eth-2ld', 'eth-subname'],
+      details:
+        'Only .eth 2LD and subname names can be checked for availability',
     })
 
   const readContractAction = getAction(client, readContract, 'readContract')
+  const leafLabel = labels[0]
 
-  const result = await readContractAction({
+  // eth-2ld: availability comes from the .eth registrar (rent/premium aware).
+  if (nameType === 'eth-2ld') {
+    return readContractAction({
+      address: getChainContractAddress({
+        chain: client.chain,
+        contract: 'ensEthRegistrar',
+      }),
+      abi: ethRegistrarAvailableSnippet,
+      functionName: 'isAvailable',
+      args: [leafLabel],
+    })
+  }
+
+  // eth-subname: use URv2 to find the parent registry, then check the leaf
+  // label's status. A missing parent registry means the name is available.
+  const parentRegistry = await readContractAction({
     address: getChainContractAddress({
       chain: client.chain,
-      contract: 'ensEthRegistrar',
+      contract: 'ensUniversalResolver',
     }),
-    abi: ethRegistrarAvailableSnippet,
-    functionName: 'isAvailable',
-    args: [labels[0]],
+    abi: universalResolverV2FindParentRegistrySnippet,
+    functionName: 'findParentRegistry',
+    args: [toHex(packetToBytes(name))],
   })
-  return result
+  if (parentRegistry === zeroAddress) return true
+
+  const status = await readContractAction({
+    address: parentRegistry,
+    abi: permissionedRegistryGetStatusSnippet,
+    functionName: 'getStatus',
+    args: [BigInt(labelhash(leafLabel))],
+  })
+  return status === 0
 }

--- a/packages/ensjs/src/actions/public/v2/getAvailable.ts
+++ b/packages/ensjs/src/actions/public/v2/getAvailable.ts
@@ -17,6 +17,38 @@ import type { ErrorType } from '../../../errors/utils.js'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
 import { getNameType } from '../../../utils/name/getNameType.js'
 
+/**
+ * TEMPORARY: hardcoded Universal Resolver V2 addresses used solely for the
+ * `findParentRegistry` traversal in the eth-subname availability path.
+ *
+ * Why this is needed (the URv1 / URv2 / proxy situation):
+ * - The chain config's `ensUniversalResolver` is intentionally pointed at a UR
+ *   that can RESOLVE both v1 and v2 names (records, addr, text, etc.). On
+ *   sepolia that is the unified UniversalResolverV2 `0x2f8a…`; on the local
+ *   devnet image it is the legacy `UniversalResolver` (`0x4b6a…`), which bridges
+ *   to v2 for resolution but predates the v2-only registry-traversal methods.
+ * - `findParentRegistry` is a UniversalResolverV2-only method. The devnet's
+ *   legacy `UniversalResolver` does NOT implement it (it reverts), and the
+ *   devnet's `UpgradableUniversalResolverProxy` DOES implement it but cannot
+ *   resolve unmigrated v1 names. No single devnet UR currently satisfies both
+ *   needs, so we can't use one shared `ensUniversalResolver` binding for both
+ *   resolution and traversal on that image.
+ * - On sepolia the same address (`0x2f8a…`) happens to do both, so this map
+ *   simply mirrors the config value there.
+ *
+ * Once the devnet image ships a unified UniversalResolverV2 that resolves v1
+ * names AND exposes `findParentRegistry` (matching sepolia's `0x2f8a…`), delete
+ * this map and read the address from `getChainContractAddress({ contract:
+ * 'ensUniversalResolver' })` again (or introduce a dedicated
+ * `ensUniversalResolverV2` contract key).
+ */
+const TEMP_UNIVERSAL_RESOLVER_V2_BY_CHAIN_ID: Record<number, `0x${string}`> = {
+  // sepolia: unified UniversalResolverV2 (resolves v1+v2 AND has findParentRegistry)
+  11155111: '0x2f8a180604c42457cb56c7c4f708748ff1f91df1',
+  // local devnet: UpgradableUniversalResolverProxy (has findParentRegistry)
+  31337: '0x4C2F7092C2aE51D986bEFEe378e50BD4dB99C901',
+}
+
 export type GetAvailableParameters = {
   /**
    * Name to check availability for. Only `.eth` names are supported:
@@ -107,11 +139,19 @@ export async function getAvailable<chain extends Chain>(
 
   // eth-subname: use URv2 to find the parent registry, then check the leaf
   // label's status. A missing parent registry means the name is available.
-  const parentRegistry = await readContractAction({
-    address: getChainContractAddress({
+  //
+  // TEMPORARY: `findParentRegistry` is a UniversalResolverV2-only method, but
+  // the configured `ensUniversalResolver` is not always a URv2 that exposes it
+  // (see TEMP_UNIVERSAL_RESOLVER_V2_BY_CHAIN_ID above). Fall back to the chain
+  // config when no temporary override is registered for this chain.
+  const universalResolverV2Address =
+    TEMP_UNIVERSAL_RESOLVER_V2_BY_CHAIN_ID[client.chain.id] ??
+    getChainContractAddress({
       chain: client.chain,
       contract: 'ensUniversalResolver',
-    }),
+    })
+  const parentRegistry = await readContractAction({
+    address: universalResolverV2Address,
     abi: universalResolverV2FindParentRegistrySnippet,
     functionName: 'findParentRegistry',
     args: [toHex(packetToBytes(name))],

--- a/packages/ensjs/src/clients/l1.ts
+++ b/packages/ensjs/src/clients/l1.ts
@@ -165,7 +165,7 @@ export const ensL1Contracts = {
       address: '0x7cD0016F722f34394110738eEc10265b00c6C7d9',
     },
     ensUniversalResolver: {
-      address: '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe',
+      address: '0x2f8a180604c42457cb56c7c4f708748ff1f91df1',
     },
     ensPermissionedResolverImpl: {
       address: '0xdcE5205A553573FFd47629327DDdf36186022FfA',

--- a/packages/ensjs/src/test/addTestContracts.ts
+++ b/packages/ensjs/src/test/addTestContracts.ts
@@ -68,7 +68,7 @@ export const localhost = {
       address: deploymentAddresses.ENSRegistry,
     },
     ensUniversalResolver: {
-      address: deploymentAddresses.UniversalResolver,
+      address: deploymentAddresses.UpgradableUniversalResolverProxy,
     },
     multicall3: {
       address: deploymentAddresses.Multicall,

--- a/packages/ensjs/src/test/addTestContracts.ts
+++ b/packages/ensjs/src/test/addTestContracts.ts
@@ -68,7 +68,7 @@ export const localhost = {
       address: deploymentAddresses.ENSRegistry,
     },
     ensUniversalResolver: {
-      address: deploymentAddresses.UpgradableUniversalResolverProxy,
+      address: deploymentAddresses.UniversalResolver,
     },
     multicall3: {
       address: deploymentAddresses.Multicall,


### PR DESCRIPTION
Extend `getAvailable` to support eth-subname names (e.g. `sub.name.eth`) in addition to eth-2ld names, and fix the Universal Resolver addresses the lib resolves against.

## `getAvailable`
- **eth-2ld**: unchanged — uses the `.eth` registrar's `isAvailable` (grace/premium aware).
- **eth-subname** (3LD and beyond): traverses the registry tree via URv2's `findParentRegistry` to locate the parent registry, then checks the leaf label's status with `getStatus`.
  - A label is available only when its status is `AVAILABLE (0)`, which correctly distinguishes `RESERVED (1)` from `AVAILABLE` — the registry's `findOwner` returns the zero address for both, so `getStatus` is used instead.
  - A missing parent registry (zero address) means the name is available.
- DNS names (other-2ld / other-subname) and TLDs remain unsupported (DNS has both on-chain and off-chain import paths, so a single availability answer would be ambiguous).

Adds ABI snippets:
- `universalResolverV2FindOwnerSnippet`
- `universalResolverV2FindParentRegistrySnippet`
- `permissionedRegistryGetStatusSnippet`

## Universal Resolver address fixes
The previously configured Sepolia UR (`0xeEeE…EeEe`, `UpgradableUniversalResolverProxy`) is **stale** — it delegates to an old implementation (`0x6d80…`) pointing at an abandoned RootRegistry (`0x11b5…`), so it returned `0x0` / `ResolverNotFound` for both v1 and v2 names. Fixes:

- **`l1.ts` (Sepolia)**: `ensUniversalResolver` → `0x2f8a180604c42457cb56c7c4f708748ff1f91df1`, the canonical `UniversalResolverV2` (RootRegistry `0xc960…`) that resolves both v1 and v2 names and exposes `findParentRegistry`. Verified on-chain (e.g. `fox.eth`, `fresh.eth` resolve correctly).
- **`addTestContracts.ts` (devnet)**: `ensUniversalResolver` → legacy `UniversalResolver` (`0x4b6a…`), which resolves both v1 and v2 names. The devnet `UpgradableUniversalResolverProxy` cannot resolve unmigrated v1 names, which broke v1-name record tests.

> Note: the stale Sepolia proxy `0xeEeE…` should be upgraded by the protocol team (`upgradeTo(0x2f8a…)`); until then ensjs points at the impl directly.

## Temporary `findParentRegistry` hardcode (`getAvailable.ts`)
`findParentRegistry` is a URv2-only method. On the **devnet image**, no single UR both resolves v1 names and exposes `findParentRegistry`:
- the legacy `UniversalResolver` (`0x4b6a…`) resolves v1+v2 but lacks `findParentRegistry`,
- the `UpgradableUniversalResolverProxy` (`0x4C2F…`) has `findParentRegistry` but cannot resolve unmigrated v1 names.

So `getAvailable` temporarily uses a per-chain hardcoded URv2 address (`TEMP_UNIVERSAL_RESOLVER_V2_BY_CHAIN_ID`: sepolia `0x2f8a…`, devnet `0x4C2F…`) for the `findParentRegistry` call, falling back to the chain config otherwise. This is documented for removal once the devnet ships a unified URv2 matching Sepolia (or a dedicated `ensUniversalResolverV2` contract key is introduced).
