### PR TITLE
refactor(ensjs): use UR.findOwner for v2 getOwner

### DIFF
--- a/packages/ensjs/src/actions/public/v2/getOwner.test.ts
+++ b/packages/ensjs/src/actions/public/v2/getOwner.test.ts
@@ -1,25 +1,20 @@
 import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
-import {
-  publicClient as client,
-  deploymentAddresses,
-} from '../../../test/addTestContracts.js'
+import { publicClient as client } from '../../../test/addTestContracts.js'
 import { getOwner } from './getOwner.js'
 
 describe('getOwner', () => {
   it('returns the owner address for a V2 name', async () => {
     const owner = await getOwner(client, {
-      registryAddress: deploymentAddresses.ETHRegistry,
-      label: 'example',
+      name: 'example.eth',
     })
 
     expect(owner).not.toEqual(zeroAddress)
   })
 
-  it('returns zero address for a non-existent label', async () => {
+  it('returns zero address for a non-existent name', async () => {
     const owner = await getOwner(client, {
-      registryAddress: deploymentAddresses.ETHRegistry,
-      label: 'thislabeldoesnotexistatall',
+      name: 'thislabeldoesnotexistatall.eth',
     })
 
     expect(owner).toEqual(zeroAddress)

--- a/packages/ensjs/src/actions/public/v2/getOwner.ts
+++ b/packages/ensjs/src/actions/public/v2/getOwner.ts
@@ -1,32 +1,55 @@
-import { permissionedRegistryGetStateSnippet } from '@ensdomains/ensjs-abi/v2/permissionedRegistry'
-import { type Address, type Client, labelhash } from 'viem'
-import { type ReadContractErrorType, readContract } from 'viem/actions'
-import { getAction } from 'viem/utils'
+import { universalResolverV2FindOwnerSnippet } from '@ensdomains/ensjs-abi/universalResolver'
+import type {
+  Address,
+  Chain,
+  NamehashErrorType,
+  ReadContractErrorType,
+} from 'viem'
+import { readContract } from 'viem/actions'
+import { packetToBytes } from 'viem/ens'
+import {
+  type GetChainContractAddressErrorType,
+  getAction,
+  toHex,
+} from 'viem/utils'
+import type { RequireClientContracts } from '../../../clients/shared.js'
+import { getChainContractAddress } from '../../../clients/shared.js'
 import { ASSERT_NO_TYPE_ERROR } from '../../../types/internal.js'
 
 export type GetOwnerParameters = {
-  registryAddress: Address
-  label: string
+  name: string
 }
 
-export type GetOwnerErrorType = ReadContractErrorType
+export type GetOwnerReturnType = Address
 
-export async function getOwner(
-  client: Client,
-  { registryAddress, label }: GetOwnerParameters,
-): Promise<Address> {
+export type GetOwnerErrorType =
+  | GetChainContractAddressErrorType
+  | ReadContractErrorType
+  | NamehashErrorType
+
+/**
+ * Find the owner for a V2 name of any depth.
+ * @param client - {@link Client}
+ * @param parameters - {@link GetOwnerParameters}
+ * @returns The owner address, or the zero address if unowned or not found. {@link GetOwnerReturnType}
+ */
+export async function getOwner<chain extends Chain>(
+  client: RequireClientContracts<chain, 'ensUniversalResolver'>,
+  { name }: GetOwnerParameters,
+): Promise<GetOwnerReturnType> {
   ASSERT_NO_TYPE_ERROR(client)
+
+  const contractAddress = getChainContractAddress({
+    chain: client.chain,
+    contract: 'ensUniversalResolver',
+  })
 
   const readContractAction = getAction(client, readContract, 'readContract')
 
-  const labelHash = BigInt(labelhash(label))
-
-  const state = await readContractAction({
-    address: registryAddress,
-    abi: permissionedRegistryGetStateSnippet,
-    functionName: 'getState',
-    args: [labelHash],
+  return readContractAction({
+    address: contractAddress,
+    abi: universalResolverV2FindOwnerSnippet,
+    functionName: 'findOwner',
+    args: [toHex(packetToBytes(name))],
   })
-
-  return state.latestOwner
 }


### PR DESCRIPTION
## Summary
Refactors the v2 `getOwner` action to use `UniversalResolver.findOwner` instead of reading `getState` directly on a specific registry.

This lets it resolve owners for `.eth` names of **any depth** (the UR recursively traverses the registry tree via `LibRegistry.findOwner`), and aligns the action with the existing `getNameRegistries` pattern.

## Changes
- **`getOwner.ts`**: New signature `{ name, address? }` (was `{ registryAddress, label }`). Uses `RequireClientContracts<chain, 'ensUniversalResolver'>`, falls back to the chain's `ensUniversalResolver` contract address, DNS-encodes the name, and calls `universalResolverV2FindOwnerSnippet`'s `findOwner`. Returns the owner address, or the zero address if unowned/not found.
- **`getOwner.test.ts`**: Updated to pass full `.eth` names + the `UniversalResolverV2` deployment address.

## Notes
- This is an intentional breaking change to the parameter shape; the v2 `getOwner` is only re-exported via `src/exports/public/v2.ts` and not consumed internally elsewhere.

## Test plan
- [x] `pnpm -F @ensdomains/ensjs test src/actions/public/v2/getOwner.test.ts` — 2/2 passing