### PR TITLE
feat(ensjs-abi): add BaseRegistrar admin + wrapETH2LD snippets

### DIFF
--- a/packages/ensjs-abi/src/v1/baseRegistrar.ts
+++ b/packages/ensjs-abi/src/v1/baseRegistrar.ts
@@ -142,6 +142,84 @@ export const baseRegistrarReclaimSnippet = [
   },
 ] as const
 
+export const baseRegistrarRegisterSnippet = [
+  {
+    inputs: [
+      {
+        name: 'id',
+        type: 'uint256',
+      },
+      {
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        name: 'duration',
+        type: 'uint256',
+      },
+    ],
+    name: 'register',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+export const baseRegistrarAddControllerSnippet = [
+  {
+    inputs: [
+      {
+        name: 'controller',
+        type: 'address',
+      },
+    ],
+    name: 'addController',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+export const baseRegistrarOwnerSnippet = [
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+export const baseRegistrarControllersSnippet = [
+  {
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'controllers',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
 export const baseRegistrarSafeTransferFromSnippet = [
   ...erc721SafeTransferFromSnippet,
 ] as const

--- a/packages/ensjs-abi/src/v1/nameWrapper.ts
+++ b/packages/ensjs-abi/src/v1/nameWrapper.ts
@@ -370,6 +370,39 @@ export const nameWrapperWrapSnippet = [
   },
 ] as const
 
+export const nameWrapperWrapEth2ldSnippet = [
+  ...nameWrapperErrors,
+  {
+    inputs: [
+      {
+        name: 'label',
+        type: 'string',
+      },
+      {
+        name: 'wrappedOwner',
+        type: 'address',
+      },
+      {
+        name: 'ownerControlledFuses',
+        type: 'uint16',
+      },
+      {
+        name: 'resolver',
+        type: 'address',
+      },
+    ],
+    name: 'wrapETH2LD',
+    outputs: [
+      {
+        name: 'tokenId',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
 export const nameWrapperUnwrapSnippet = [
   ...nameWrapperErrors,
   {

--- a/packages/ensjs/src/contracts/index.ts
+++ b/packages/ensjs/src/contracts/index.ts
@@ -42,11 +42,15 @@ export {
   universalResolverReverseWithGatewaysSnippet,
 } from '@ensdomains/ensjs-abi/universalResolver'
 export {
+  baseRegistrarAddControllerSnippet,
   baseRegistrarAvailableSnippet,
+  baseRegistrarControllersSnippet,
   baseRegistrarGracePeriodSnippet,
   baseRegistrarNameExpiresSnippet,
   baseRegistrarOwnerOfSnippet,
+  baseRegistrarOwnerSnippet,
   baseRegistrarReclaimSnippet,
+  baseRegistrarRegisterSnippet,
   baseRegistrarSafeTransferFromSnippet,
   baseRegistrarSafeTransferFromWithDataSnippet,
 } from '@ensdomains/ensjs-abi/v1/baseRegistrar'
@@ -76,6 +80,7 @@ export {
   nameWrapperSetSubnodeRecordSnippet,
   nameWrapperUnwrapEth2ldSnippet,
   nameWrapperUnwrapSnippet,
+  nameWrapperWrapEth2ldSnippet,
   nameWrapperWrapSnippet,
 } from '@ensdomains/ensjs-abi/v1/nameWrapper'
 export {


### PR DESCRIPTION
Add register/addController/owner/controllers snippets to v1/baseRegistrar and wrapETH2LD to v1/nameWrapper, re-exported from ensjs contracts.