### PR TITLE
feat: update Sepolia subgraph URL to v1-graphql.ens.dev

### DIFF
--- a/packages/ensjs/src/actions/subgraph/getSubgraphRegistrant.ts
+++ b/packages/ensjs/src/actions/subgraph/getSubgraphRegistrant.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-request'
-import { type Address, getAddress, labelhash } from 'viem'
+import { type Address, getAddress, namehash } from 'viem'
 import type { ChainWithSubgraph } from '../../clients/l1.js'
 import { UnsupportedNameTypeError } from '../../errors/general.js'
 import { getNameType } from '../../utils/name/getNameType.js'
@@ -16,18 +16,22 @@ export type GetSubgraphRegistrantErrorType = UnsupportedNameTypeError | Error
 
 const query = gql`
   query getSubgraphRegistrant($id: String!) {
-    registration(id: $id) {
-      registrant {
-        id
+    domain(id: $id) {
+      registration {
+        registrant {
+          id
+        }
       }
     }
   }
 `
 
 type SubgraphResult = {
-  registration?: {
-    registrant: {
-      id: Address
+  domain?: {
+    registration?: {
+      registrant: {
+        id: Address
+      }
     }
   }
 }
@@ -55,7 +59,6 @@ const getSubgraphRegistrant = async <_chain extends ChainWithSubgraph>(
   client: { chain: _chain },
   { name }: GetSubgraphRegistrantParameters,
 ): Promise<GetSubgraphRegistrantReturnType> => {
-  const labels = name.split('.')
   const nameType = getNameType(name)
   if (nameType !== 'eth-2ld')
     throw new UnsupportedNameTypeError({
@@ -67,11 +70,11 @@ const getSubgraphRegistrant = async <_chain extends ChainWithSubgraph>(
   const subgraphClient = createSubgraphClient(client)
 
   const result = await subgraphClient.request<SubgraphResult>(query, {
-    id: labelhash(labels[0]),
+    id: namehash(name),
   })
 
-  if (result?.registration?.registrant?.id)
-    return getAddress(result.registration.registrant.id)
+  if (result?.domain?.registration?.registrant?.id)
+    return getAddress(result.domain.registration.registrant.id)
   return null
 }
 

--- a/packages/ensjs/src/clients/l1.ts
+++ b/packages/ensjs/src/clients/l1.ts
@@ -236,7 +236,7 @@ export const ensL1Subgraphs = {
   },
   [supportedL1Chains.sepolia]: {
     ens: {
-      url: 'https://api.sepolia.ensnode.io/subgraph',
+      url: 'https://v1-graphql.ens.dev/subgraph',
     },
   },
 } as const satisfies Record<SupportedL1ChainId, EnsSubgraph>


### PR DESCRIPTION
Updates the Sepolia ENS subgraph endpoint from the deprecated `api.sepolia.ensnode.io` (now returning payment errors) to `v1-graphql.ens.dev`.

### Changes
- `packages/ensjs/src/clients/l1.ts`: Changed Sepolia subgraph URL
- `packages/ensjs/src/actions/subgraph/getSubgraphRegistrant.ts`: Fixed registrant query to use `domain → registration → registrant` path instead of direct `registration(id: labelhash)`, because the new Ponder-based indexer uses namehash (not labelhash) as the registration ID. This is backwards-compatible with the old graph-node indexer since both support querying registrations through the domain entity.

### Verification
- New endpoint confirmed indexing Sepolia at ~11.3M blocks
- Old endpoint returns `payment required` auth errors
- E2E validated: real ensjs subgraph actions (`getNamesForAddress`, `getSubgraphRecords`, `getSubnames`, `getSubgraphRegistrant`) all succeed against the new URL
- `biome check` passes